### PR TITLE
Set Page up to accept components as props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to
 ### Added
 
 - TypeScript support
+- `Page` with support for an array of components to render as children

--- a/docs/adr/0007-make-remultiform-configuration-driven.md
+++ b/docs/adr/0007-make-remultiform-configuration-driven.md
@@ -1,0 +1,37 @@
+# 7. Make remultiform configuration driven
+
+Date: 2019-10-30
+
+## Status
+
+Accepted
+
+## Context
+
+We want to build a reusable React library, that generates multipage forms
+quickly. We need logic that extends beyond simple "show this element on this
+page", such as conditional logic for displaying sections dependant on values in
+other sections, and to skip pages based on values elsewhere in the journey.
+
+## Decision
+
+We will build remultiform to export a series of small orchestration components.
+We will pass the entire multipage form configuration in via props to those
+orchestrators. The configuration should be agnostic of the set of components it
+might receive.
+
+## Consequences
+
+We believe that separating the logic to render forms and routing to subpages of
+multipage forms from the definition of those forms will speed up development of
+multipage forms in general.
+
+Putting logic into that configuration adds some complexity in building type
+definitions for that configuration that is generic enough to be reused in many
+different situations and agnostic of the components used. We believe that is an
+ok trade-off to make in exchange for being able to build new forms more quickly,
+than if we had to build each multipage form as a series of pages.
+
+We also believe that the complexity of having generic orchestrators ingesting
+varied configuration is a trade-off worth making in exchange for making it
+possible to specify varied forms quickly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4619,8 +4619,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -4853,7 +4852,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -5161,8 +5159,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5676,7 +5673,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5725,8 +5721,7 @@
     "react-is": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
-      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==",
-      "dev": true
+      "integrity": "sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw=="
     },
     "react-test-renderer": {
       "version": "16.11.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "peerDependencies": {
     "react": ">= 16"
   },
+  "dependencies": {
+    "prop-types": "^15.7.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",

--- a/src/components/Page.test.tsx
+++ b/src/components/Page.test.tsx
@@ -1,10 +1,69 @@
-import React from "react";
+import PropTypes, { ValidationMap } from "prop-types";
+import React, { FunctionComponent, ImgHTMLAttributes } from "react";
 import renderer from "react-test-renderer";
 
-import Page from "./Page";
+import Page, { PageComponent, PageComponents } from "./Page";
 
-it("renders correctly", () => {
-  const component = renderer.create(<Page />);
+interface TestProps {
+  content: string;
+}
+
+class TestClassComponent extends React.Component<TestProps> {
+  static propTypes: ValidationMap<TestProps> = {
+    content: PropTypes.string.isRequired
+  };
+
+  render(): JSX.Element {
+    const { content } = this.props;
+
+    return <div>{content}</div>;
+  }
+}
+
+const TestFunctionComponent: FunctionComponent<TestProps> = ({ content }) => (
+  <div>{content}</div>
+);
+
+TestFunctionComponent.propTypes = {
+  content: PropTypes.string.isRequired
+};
+
+it("renders correctly with all props", () => {
+  const component = renderer.create(
+    <Page
+      components={
+        [
+          {
+            id: "test-div",
+            Component: "div"
+          } as PageComponent,
+          {
+            id: "test-img",
+            Component: "img",
+            props: {
+              src: "test.png"
+            }
+          } as PageComponent<ImgHTMLAttributes<HTMLImageElement>>,
+          {
+            id: "test-class",
+            Component: TestClassComponent,
+            props: {
+              content: "test class content"
+            }
+          } as PageComponent<TestProps>,
+          {
+            id: "test-function",
+            Component: TestFunctionComponent,
+            props: {
+              content: "test function content"
+            }
+          } as PageComponent<TestProps>
+        ] as PageComponents<
+          {} | ImgHTMLAttributes<HTMLImageElement> | TestProps
+        >
+      }
+    />
+  );
 
   expect(component).toMatchSnapshot();
 });

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -13,7 +13,7 @@ export interface PageProps<P = {}> {
   components: PageComponents<P>;
 }
 
-class Page<P> extends React.Component<PageProps<P>> {
+export class Page<P> extends React.Component<PageProps<P>> {
   static propTypes: ValidationMap<PageProps> = {
     components: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,8 +1,39 @@
-import React, { Component } from "react";
+import PropTypes, { ValidationMap } from "prop-types";
+import React, { Attributes, ComponentType } from "react";
 
-class Page extends Component {
+export interface PageComponent<P = {}> {
+  id: string;
+  Component: string | ComponentType<Attributes | P>;
+  props?: P;
+}
+
+export type PageComponents<P = {}> = PageComponent<P>[];
+
+export interface PageProps<P = {}> {
+  components: PageComponents<P>;
+}
+
+class Page<P> extends React.Component<PageProps<P>> {
+  static propTypes: ValidationMap<PageProps> = {
+    components: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        Component: PropTypes.elementType.isRequired,
+        props: PropTypes.object
+      }).isRequired
+    ).isRequired
+  };
+
   render(): JSX.Element {
-    return <div>Content goes here!</div>;
+    const { components } = this.props;
+
+    return (
+      <>
+        {components.map(({ id, Component, props }) => (
+          <Component key={id} {...props} />
+        ))}
+      </>
+    );
   }
 }
 

--- a/src/components/__snapshots__/Page.test.tsx.snap
+++ b/src/components/__snapshots__/Page.test.tsx.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<div>
-  Content goes here!
-</div>
+Array [
+  <div />,
+  <img
+    src="test.png"
+  />,
+  <div>
+    test class content
+  </div>,
+  <div>
+    test function content
+  </div>,
+]
 `;


### PR DESCRIPTION
We want to make be able to specify components to be constructed at runtime, so that we can by dynamic in their properties.

This commit adds `prop-types` as a dependency, so the libraries we build will advise on prop types even if the consumer isn't using TypeScript.

This PR also documents the approach we intend to take for this library as a whole. Please could I have some eyes on that @LBHMGeorgieva @LBHELewis.