### PR TITLE
Improve the type inference of page components using a wrapper

### DIFF
--- a/examples/next-kittens/pages/[slug].tsx
+++ b/examples/next-kittens/pages/[slug].tsx
@@ -1,6 +1,6 @@
 import { NextPageContext } from "next";
 import React, { Component } from "react";
-import { Page, PageComponents } from "remultiform";
+import { Page, wrapPageComponent } from "remultiform";
 
 interface SlugPageProps {
   kittenDimensions: string[];
@@ -16,15 +16,15 @@ class SlugPage extends Component<SlugPageProps> {
   render(): JSX.Element {
     const { kittenDimensions } = this.props;
 
-    const components: PageComponents = [
-      {
-        id: "image",
+    const componentWrappers = [
+      wrapPageComponent({
+        key: "image",
         Component: "img",
         props: { src: `https://placekitten.com/${kittenDimensions.join("/")}` }
-      }
+      })
     ];
 
-    return <Page components={components} />;
+    return <Page componentWrappers={componentWrappers} />;
   }
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,7 @@ module.exports = {
       tsconfigOverride: {
         exclude: [
           ...tsconfig.exclude,
+          "**/__fixtures__/**/*",
           "**/__tests__/**/*",
           "**/*.spec.*",
           "**/*.test.*"

--- a/src/__fixtures__/components/TestClassComponent.tsx
+++ b/src/__fixtures__/components/TestClassComponent.tsx
@@ -1,0 +1,20 @@
+import PropTypes, { ValidationMap } from "prop-types";
+import React from "react";
+
+export interface TestClassComponentProps {
+  content: string;
+}
+
+class TestClassComponent extends React.Component<TestClassComponentProps> {
+  static propTypes: ValidationMap<TestClassComponentProps> = {
+    content: PropTypes.string.isRequired
+  };
+
+  render(): JSX.Element {
+    const { content } = this.props;
+
+    return <div>{content}</div>;
+  }
+}
+
+export default TestClassComponent;

--- a/src/__fixtures__/components/TestFunctionComponent.tsx
+++ b/src/__fixtures__/components/TestFunctionComponent.tsx
@@ -1,0 +1,16 @@
+import PropTypes from "prop-types";
+import React, { FunctionComponent } from "react";
+
+export interface TestFunctionComponentProps {
+  content: string;
+}
+
+const TestFunctionComponent: FunctionComponent<TestFunctionComponentProps> = ({
+  content
+}) => <div>{content}</div>;
+
+TestFunctionComponent.propTypes = {
+  content: PropTypes.string.isRequired
+};
+
+export default TestFunctionComponent;

--- a/src/__fixtures__/forms/singleStepForm.ts
+++ b/src/__fixtures__/forms/singleStepForm.ts
@@ -1,0 +1,42 @@
+import { wrapPageComponent } from "../../helpers/PageComponentWrapper";
+
+import TestClassComponent from "../components/TestClassComponent";
+import TestFunctionComponent from "../components/TestFunctionComponent";
+
+const singleStepForm = {
+  steps: [
+    {
+      id: "test-step",
+      componentWrappers: [
+        wrapPageComponent({
+          key: "test-div",
+          Component: "div",
+          props: {}
+        }),
+        wrapPageComponent({
+          key: "test-img",
+          Component: "img",
+          props: {
+            src: "test.png"
+          }
+        }),
+        wrapPageComponent({
+          key: "test-class",
+          Component: TestClassComponent,
+          props: {
+            content: "test class content"
+          }
+        }),
+        wrapPageComponent({
+          key: "test-function",
+          Component: TestFunctionComponent,
+          props: {
+            content: "test function content"
+          }
+        })
+      ]
+    }
+  ]
+};
+
+export default singleStepForm;

--- a/src/components/Page.test.tsx
+++ b/src/components/Page.test.tsx
@@ -1,68 +1,13 @@
-import PropTypes, { ValidationMap } from "prop-types";
-import React, { FunctionComponent, ImgHTMLAttributes } from "react";
+import React from "react";
 import renderer from "react-test-renderer";
 
-import Page, { PageComponent, PageComponents } from "./Page";
+import Page from "./Page";
 
-interface TestProps {
-  content: string;
-}
-
-class TestClassComponent extends React.Component<TestProps> {
-  static propTypes: ValidationMap<TestProps> = {
-    content: PropTypes.string.isRequired
-  };
-
-  render(): JSX.Element {
-    const { content } = this.props;
-
-    return <div>{content}</div>;
-  }
-}
-
-const TestFunctionComponent: FunctionComponent<TestProps> = ({ content }) => (
-  <div>{content}</div>
-);
-
-TestFunctionComponent.propTypes = {
-  content: PropTypes.string.isRequired
-};
+import singleStepForm from "../__fixtures__/forms/singleStepForm";
 
 it("renders correctly with all props", () => {
   const component = renderer.create(
-    <Page
-      components={
-        [
-          {
-            id: "test-div",
-            Component: "div"
-          } as PageComponent,
-          {
-            id: "test-img",
-            Component: "img",
-            props: {
-              src: "test.png"
-            }
-          } as PageComponent<ImgHTMLAttributes<HTMLImageElement>>,
-          {
-            id: "test-class",
-            Component: TestClassComponent,
-            props: {
-              content: "test class content"
-            }
-          } as PageComponent<TestProps>,
-          {
-            id: "test-function",
-            Component: TestFunctionComponent,
-            props: {
-              content: "test function content"
-            }
-          } as PageComponent<TestProps>
-        ] as PageComponents<
-          {} | ImgHTMLAttributes<HTMLImageElement> | TestProps
-        >
-      }
-    />
+    <Page componentWrappers={singleStepForm.steps[0].componentWrappers} />
   );
 
   expect(component).toMatchSnapshot();

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,39 +1,24 @@
 import PropTypes, { ValidationMap } from "prop-types";
-import React, { Attributes, ComponentType } from "react";
+import React from "react";
 
-export interface PageComponent<P = {}> {
-  id: string;
-  Component: string | ComponentType<Attributes | P>;
-  props?: P;
+import PageComponentWrapper, {
+  pageComponentWrapperPropType
+} from "../helpers/PageComponentWrapper";
+
+export interface PageProps {
+  componentWrappers: PageComponentWrapper[];
 }
 
-export type PageComponents<P = {}> = PageComponent<P>[];
-
-export interface PageProps<P = {}> {
-  components: PageComponents<P>;
-}
-
-export class Page<P> extends React.Component<PageProps<P>> {
+export class Page extends React.Component<PageProps> {
   static propTypes: ValidationMap<PageProps> = {
-    components: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        Component: PropTypes.elementType.isRequired,
-        props: PropTypes.object
-      }).isRequired
-    ).isRequired
+    componentWrappers: PropTypes.arrayOf(pageComponentWrapperPropType)
+      .isRequired
   };
 
   render(): JSX.Element {
-    const { components } = this.props;
+    const { componentWrappers } = this.props;
 
-    return (
-      <>
-        {components.map(({ id, Component, props }) => (
-          <Component key={id} {...props} />
-        ))}
-      </>
-    );
+    return <>{componentWrappers.map(({ key, render }) => render(key))}</>;
   }
 }
 

--- a/src/helpers/PageComponentWrapper.test.ts
+++ b/src/helpers/PageComponentWrapper.test.ts
@@ -1,0 +1,92 @@
+import renderer from "react-test-renderer";
+
+import TestClassComponent from "../__fixtures__/components/TestClassComponent";
+import TestFunctionComponent from "../__fixtures__/components/TestFunctionComponent";
+
+import { wrapPageComponent } from "./PageComponentWrapper";
+
+describe("#render", () => {
+  it("renders correctly for intrinsic elements without providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-function",
+      Component: "img",
+      props: {
+        src: "test.png"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render());
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders correctly for class components without providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-class",
+      Component: TestClassComponent,
+      props: {
+        content: "test class content"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render());
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders correctly for function components without providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-function",
+      Component: TestFunctionComponent,
+      props: {
+        content: "test function content"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render());
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders correctly for intrinsic elements when providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-function",
+      Component: "img",
+      props: {
+        src: "test.png"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render("test-key"));
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders correctly for class components when providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-class",
+      Component: TestClassComponent,
+      props: {
+        content: "test class content"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render("test-key"));
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it("renders correctly for function components when providing a key", () => {
+    const componentWrapper = wrapPageComponent({
+      key: "test-function",
+      Component: TestFunctionComponent,
+      props: {
+        content: "test function content"
+      }
+    });
+
+    const component = renderer.create(componentWrapper.render("test-key"));
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/src/helpers/PageComponentWrapper.tsx
+++ b/src/helpers/PageComponentWrapper.tsx
@@ -1,0 +1,37 @@
+import PropTypes from "prop-types";
+import React, { ElementType, Key } from "react";
+
+export interface PageComponent<
+  C extends ElementType<P>,
+  P = C extends ElementType<infer T> ? T : {}
+> {
+  key: Key;
+  Component: C;
+  props: JSX.LibraryManagedAttributes<C, P>;
+}
+
+export interface PageComponentWrapper {
+  key: Key;
+  render(key?: Key): JSX.Element;
+}
+
+export const pageComponentWrapperPropType = PropTypes.exact({
+  key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  render: PropTypes.func.isRequired
+}).isRequired;
+
+export const wrapPageComponent = <
+  C extends ElementType<P>,
+  P = C extends ElementType<infer T> ? T : {}
+>({
+  key,
+  Component,
+  props
+}: PageComponent<C, P>): PageComponentWrapper => ({
+  key,
+  render(k?: Key): JSX.Element {
+    return <Component key={k !== undefined ? k : key} {...props} />;
+  }
+});
+
+export default PageComponentWrapper;

--- a/src/helpers/__snapshots__/PageComponentWrapper.test.ts.snap
+++ b/src/helpers/__snapshots__/PageComponentWrapper.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#render renders correctly for class components when providing a key 1`] = `
+<div>
+  test class content
+</div>
+`;
+
+exports[`#render renders correctly for class components without providing a key 1`] = `
+<div>
+  test class content
+</div>
+`;
+
+exports[`#render renders correctly for function components when providing a key 1`] = `
+<div>
+  test function content
+</div>
+`;
+
+exports[`#render renders correctly for function components without providing a key 1`] = `
+<div>
+  test function content
+</div>
+`;
+
+exports[`#render renders correctly for intrinsic elements when providing a key 1`] = `
+<img
+  src="test.png"
+/>
+`;
+
+exports[`#render renders correctly for intrinsic elements without providing a key 1`] = `
+<img
+  src="test.png"
+/>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./components/Page";
+export * from "./helpers/PageComponentWrapper";


### PR DESCRIPTION
All `PageComponent`s ultimately render a `JSX.Element` from the same set of inputs. By using a non-generic wrapper interface, we can use TypeScript's type inference to force the type of the props to match those expected by the component.