### PR TITLE
Create an `Orchestrator` component to render the appropriate `Page`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,17 @@
 /* eslint-env node */
-const sharedPlugins = ["react", "prettier"];
-const sharedRuleExtends = ["eslint:recommended", "plugin:react/recommended"];
-const sharedRulePrettierExtends = ["prettier", "prettier/react"];
+const sharedPlugins = ["react", "react-hooks", "prettier"];
+const sharedExtends = ["eslint:recommended", "plugin:react/recommended"];
+const sharedPrettierExtends = ["prettier", "prettier/react"];
+const sharedRules = {
+  "react-hooks/rules-of-hooks": "error",
+  "react-hooks/exhaustive-deps": "warn"
+};
 
 module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: [...sharedPlugins],
-  extends: [...sharedRuleExtends, ...sharedRulePrettierExtends],
+  extends: [...sharedExtends, ...sharedPrettierExtends],
+  rules: { ...sharedRules },
   settings: {
     react: {
       version: "detect"
@@ -17,12 +22,13 @@ module.exports = {
       files: ["**/*.ts", "**/*.tsx"],
       plugins: [...sharedPlugins, "@typescript-eslint"],
       extends: [
-        ...sharedRuleExtends,
+        ...sharedExtends,
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
-        ...sharedRulePrettierExtends,
+        ...sharedPrettierExtends,
         "prettier/@typescript-eslint"
-      ]
+      ],
+      rules: { ...sharedRules }
     }
   ]
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to
 
 - TypeScript support
 - `Page` with support for an array of components to render as children
+- `Orchestrator` to orchestrate rendering the appropriate `Page`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to
 - TypeScript support
 - `Page` with support for an array of components to render as children
 - `Orchestrator` to orchestrate rendering the appropriate `Page`
+- `next-kittens` example

--- a/examples/next-kittens/README.md
+++ b/examples/next-kittens/README.md
@@ -26,5 +26,4 @@ This example shows how to integrate Remultiform with Next.js.
    npm run dev
    ```
 
-1. Navigate to `http://localhost:3000/200x300`. The slug of the page is in the
-   format `{width}x{length}` of the kitten picture you want.
+1. Navigate to `http://localhost:3000`

--- a/examples/next-kittens/__tests__/pages/[slug].test.tsx
+++ b/examples/next-kittens/__tests__/pages/[slug].test.tsx
@@ -1,12 +1,10 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { create } from "react-test-renderer";
 
 import SlugPage from "../../pages/[slug]";
 
 it("renders correctly with all props", () => {
-  const component = renderer.create(
-    <SlugPage kittenDimensions={["200", "300"]} />
-  );
+  const component = create(<SlugPage slug="big-kitten" />);
 
   expect(component).toMatchSnapshot();
 });

--- a/examples/next-kittens/__tests__/pages/__snapshots__/[slug].test.tsx.snap
+++ b/examples/next-kittens/__tests__/pages/__snapshots__/[slug].test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`renders correctly with all props 1`] = `
 <img
-  src="https://placekitten.com/200/300"
+  src="https://placekitten.com/900/600"
 />
 `;

--- a/examples/next-kittens/pages/[slug].tsx
+++ b/examples/next-kittens/pages/[slug].tsx
@@ -1,30 +1,45 @@
 import { NextPageContext } from "next";
 import React, { Component } from "react";
-import { Page, wrapPageComponent } from "remultiform";
+import { Orchestrator, Step, wrapPageComponent } from "remultiform";
 
 interface SlugPageProps {
-  kittenDimensions: string[];
+  slug: string;
 }
+
+const steps: Step[] = [
+  {
+    key: "small-kitten",
+    componentWrappers: [
+      wrapPageComponent({
+        key: "image",
+        Component: "img",
+        props: { src: `https://placekitten.com/200/300` }
+      })
+    ]
+  },
+  {
+    key: "big-kitten",
+    componentWrappers: [
+      wrapPageComponent({
+        key: "image",
+        Component: "img",
+        props: { src: `https://placekitten.com/900/600` }
+      })
+    ]
+  }
+];
 
 class SlugPage extends Component<SlugPageProps> {
   static getInitialProps({ query }: NextPageContext): SlugPageProps {
     const { slug } = query;
 
-    return { kittenDimensions: (slug as string).split("x") };
+    return { slug: slug as string };
   }
 
   render(): JSX.Element {
-    const { kittenDimensions } = this.props;
+    const { slug } = this.props;
 
-    const componentWrappers = [
-      wrapPageComponent({
-        key: "image",
-        Component: "img",
-        props: { src: `https://placekitten.com/${kittenDimensions.join("/")}` }
-      })
-    ];
-
-    return <Page componentWrappers={componentWrappers} />;
+    return <Orchestrator currentStepKey={slug} steps={steps} />;
   }
 }
 

--- a/examples/next-kittens/pages/index.tsx
+++ b/examples/next-kittens/pages/index.tsx
@@ -1,0 +1,28 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import React from "react";
+
+const IndexPage: NextPage = (): JSX.Element => {
+  const router = useRouter();
+
+  return (
+    <>
+      <button
+        onClick={async (): Promise<void> => {
+          await router.replace("/small-kitten");
+        }}
+      >
+        Small kitten
+      </button>
+      <button
+        onClick={async (): Promise<void> => {
+          await router.replace("/big-kitten");
+        }}
+      >
+        Big kitten
+      </button>
+    </>
+  );
+};
+
+export default IndexPage;

--- a/examples/next-kittens/tsconfig.json
+++ b/examples/next-kittens/tsconfig.json
@@ -18,6 +18,5 @@
       "remultiform": ["../../dist/index", "../../dist/module"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["**/node_modules/**/*", "__tests__/**/*"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2601,6 +2601,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz",
+      "integrity": "sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.16.0",
+    "eslint-plugin-react-hooks": "^2.2.0",
     "husky": "^3.0.9",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/src/__fixtures__/forms/multiStepForm.ts
+++ b/src/__fixtures__/forms/multiStepForm.ts
@@ -4,10 +4,10 @@ import { wrapPageComponent } from "../../helpers/PageComponentWrapper";
 import TestClassComponent from "../components/TestClassComponent";
 import TestFunctionComponent from "../components/TestFunctionComponent";
 
-const singleStepForm: { steps: Step[] } = {
+const multiStepForm: { steps: Step[] } = {
   steps: [
     {
-      key: "test-step",
+      key: "test-step-1",
       componentWrappers: [
         wrapPageComponent({
           key: "test-div",
@@ -15,17 +15,22 @@ const singleStepForm: { steps: Step[] } = {
           props: {}
         }),
         wrapPageComponent({
-          key: "test-img",
-          Component: "img",
-          props: {
-            src: "test.png"
-          }
-        }),
-        wrapPageComponent({
           key: "test-class",
           Component: TestClassComponent,
           props: {
             content: "test class content"
+          }
+        })
+      ]
+    },
+    {
+      key: "test-step-2",
+      componentWrappers: [
+        wrapPageComponent({
+          key: "test-img",
+          Component: "img",
+          props: {
+            src: "test.png"
           }
         }),
         wrapPageComponent({
@@ -40,4 +45,4 @@ const singleStepForm: { steps: Step[] } = {
   ]
 };
 
-export default singleStepForm;
+export default multiStepForm;

--- a/src/components/Orchestrator.test.tsx
+++ b/src/components/Orchestrator.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { create } from "react-test-renderer";
+
+import multiStepForm from "../__fixtures__/forms/multiStepForm";
+
+import Orchestrator from "./Orchestrator";
+
+it("renders correctly with all props", () => {
+  const component = create(
+    <Orchestrator currentStepKey="test-step-2" steps={multiStepForm.steps} />
+  );
+
+  expect(component).toMatchSnapshot();
+});
+
+it("renders correctly without `currentStepKey`", () => {
+  const component = create(<Orchestrator steps={multiStepForm.steps} />);
+
+  expect(component).toMatchSnapshot();
+});

--- a/src/components/Orchestrator.tsx
+++ b/src/components/Orchestrator.tsx
@@ -1,0 +1,52 @@
+import PropTypes, { ValidationMap } from "prop-types";
+import React, { Key } from "react";
+
+import PageComponentWrapper, {
+  pageComponentWrapperPropType
+} from "../helpers/PageComponentWrapper";
+
+import Page from "./Page";
+
+export interface Step {
+  key: Key;
+  componentWrappers: PageComponentWrapper[];
+}
+
+export interface OrchestratorProps {
+  currentStepKey?: Key | null;
+  steps: Step[];
+}
+
+export class Orchestrator extends React.Component<OrchestratorProps> {
+  static propTypes: ValidationMap<OrchestratorProps> = {
+    currentStepKey: PropTypes.string,
+    steps: PropTypes.arrayOf(
+      PropTypes.exact({
+        key: PropTypes.oneOfType([
+          PropTypes.string.isRequired,
+          PropTypes.number.isRequired
+        ]).isRequired,
+        componentWrappers: PropTypes.arrayOf(pageComponentWrapperPropType)
+          .isRequired
+      }).isRequired
+    ).isRequired
+  };
+
+  render(): JSX.Element {
+    const { currentStepKey, steps } = this.props;
+
+    const currentStep =
+      steps.find(({ key }) => key === currentStepKey) || steps[0];
+
+    return (
+      <>
+        <Page
+          key={currentStep.key}
+          componentWrappers={currentStep.componentWrappers}
+        />
+      </>
+    );
+  }
+}
+
+export default Orchestrator;

--- a/src/components/Page.test.tsx
+++ b/src/components/Page.test.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import renderer from "react-test-renderer";
+import { create } from "react-test-renderer";
 
 import Page from "./Page";
 
 import singleStepForm from "../__fixtures__/forms/singleStepForm";
 
 it("renders correctly with all props", () => {
-  const component = renderer.create(
+  const component = create(
     <Page componentWrappers={singleStepForm.steps[0].componentWrappers} />
   );
 

--- a/src/components/__snapshots__/Orchestrator.test.tsx.snap
+++ b/src/components/__snapshots__/Orchestrator.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly with all props 1`] = `
+Array [
+  <img
+    src="test.png"
+  />,
+  <div>
+    test function content
+  </div>,
+]
+`;
+
+exports[`renders correctly without \`currentStepKey\` 1`] = `
+Array [
+  <div />,
+  <div>
+    test class content
+  </div>,
+]
+`;

--- a/src/helpers/PageComponentWrapper.test.ts
+++ b/src/helpers/PageComponentWrapper.test.ts
@@ -1,4 +1,4 @@
-import renderer from "react-test-renderer";
+import { create } from "react-test-renderer";
 
 import TestClassComponent from "../__fixtures__/components/TestClassComponent";
 import TestFunctionComponent from "../__fixtures__/components/TestFunctionComponent";
@@ -15,7 +15,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render());
+    const component = create(componentWrapper.render());
 
     expect(component).toMatchSnapshot();
   });
@@ -29,7 +29,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render());
+    const component = create(componentWrapper.render());
 
     expect(component).toMatchSnapshot();
   });
@@ -43,7 +43,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render());
+    const component = create(componentWrapper.render());
 
     expect(component).toMatchSnapshot();
   });
@@ -57,7 +57,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render("test-key"));
+    const component = create(componentWrapper.render("test-key"));
 
     expect(component).toMatchSnapshot();
   });
@@ -71,7 +71,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render("test-key"));
+    const component = create(componentWrapper.render("test-key"));
 
     expect(component).toMatchSnapshot();
   });
@@ -85,7 +85,7 @@ describe("#render", () => {
       }
     });
 
-    const component = renderer.create(componentWrapper.render("test-key"));
+    const component = create(componentWrapper.render("test-key"));
 
     expect(component).toMatchSnapshot();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./components/Orchestrator";
 export * from "./components/Page";
 export * from "./helpers/PageComponentWrapper";


### PR DESCRIPTION
If there is no current step key, we assume that the user should see the first step as they will be at the beginning of the journey.

Also:

- Add ESLint rules to check for correct React hook usage.
- Update the kitten example to demonstrate usage of `Orchestrator`.