### PR TITLE
Add an explicit path to Dependabot for `next-kittens`

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,7 @@ update_configs:
     version_requirement_updates: increase_versions
 
   - package_manager: javascript
-    directory: /examples/
+    directory: /examples/next-kittens/
     update_schedule: live
     allowed_updates:
       - match:


### PR DESCRIPTION
It doesn't find the `package.json` otherwise.

Closes #14.