### PR TITLE
Set Dependabot up to auto-update example dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,4 +16,8 @@ update_configs:
       - match:
           dependency_type: all
           update_type: all
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
     version_requirement_updates: increase_versions


### PR DESCRIPTION
It will only attempt to automerge patch updates, and will wait for status checks (like CI) to pass first.

See https://dependabot.com/docs/config-file/#automerged_updates