### PR TITLE
Set Dependabot to automerge all minor version changes

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,7 +10,7 @@ update_configs:
     automerged_updates:
       - match:
           dependency_type: all
-          update_type: semver:patch
+          update_type: semver:minor
     version_requirement_updates: increase_versions
 
   - package_manager: javascript
@@ -23,5 +23,5 @@ update_configs:
     automerged_updates:
       - match:
           dependency_type: all
-          update_type: semver:patch
+          update_type: semver:minor
     version_requirement_updates: increase_versions


### PR DESCRIPTION
We have a lot of dependencies, and requiring manual review of all of them is _very_ time consuming. Packages following SemVer should never introduce breaking changes in minor versions. We might miss out on seeing the introduction of new features. We will continue to get PRs, and have their status checked by CI before merge, so updates won't be completely invisible.