### PR TITLE
Exclude empty examples from example testing

### DIFF
--- a/bin/test-examples
+++ b/bin/test-examples
@@ -12,6 +12,10 @@ function run-for-each-dir-in {
     fi
 
     if [ -d "$path" ]; then
+      if ! [ -e "$path/package.json" ]; then
+        continue
+      fi
+
       pushd "$path"
       eval "$@"
       popd


### PR DESCRIPTION
If an example doesn't have a `package.json` it also doesn't define its own tests, so should be tested another way.