### PR TITLE
Add status and info badges to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Remultiform
 
+![Project maturity](https://img.shields.io/badge/project_maturity-alpha-blue?style=for-the-badge)
+![Licence](https://img.shields.io/github/license/LBHackney-IT/remultiform?label=licence&style=for-the-badge)
+
+![CircleCI build status](https://img.shields.io/circleci/build/github/LBHackney-IT/remultiform?style=for-the-badge)
+
+![GitHub repo size](https://img.shields.io/github/repo-size/LBHackney-IT/remultiform?style=for-the-badge)
+
 The **Re**act **multi**page **form** builder
 
 **Warning: Remultiform is still in alpha. No promises of API stability are


### PR DESCRIPTION
# What?

This adds 4 new badges to the readme:

- project maturity: alpha
- licence: MIT
- CircleCI: build status
- repo size

# Why?

Badges are useful for indicating the status of a repository quickly, at a glance.