### PR TITLE
Make Dependabot update less frequently

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: javascript
     directory: /
-    update_schedule: live
+    update_schedule: daily
     allowed_updates:
       - match:
           dependency_type: all
@@ -15,7 +15,7 @@ update_configs:
 
   - package_manager: javascript
     directory: /examples/next-kittens/
-    update_schedule: live
+    update_schedule: weekly
     allowed_updates:
       - match:
           dependency_type: all


### PR DESCRIPTION
# What?

Change Dependabot to batch updates daily, instead of live, as they are published. Examples are updated weekly.

# Why?

While always being up-to-date with cutting edge releases of packages is nice, it can also result in a lot of updates. Most don't require manual reviews, but because they're automerged all the time, it can make keeping up with what's changing quite difficult.

This is a library that will be published preiodically. It's not necessary to be absolutely up-to-date all of the time.