### PR TITLE
Support pages outside of steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Added `provideDatabase` to `Orchestrator`'s props to support manually wrapping
+  steps with a `DatabaseProvider`
+
 ## [0.0.1] - 05-12-2019
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to
 - Added `provideDatabase` to `Orchestrator`'s props to support manually wrapping
   steps with a `DatabaseProvider`
 
+### Fixed
+
+- Stopped throwing an error when attempting to transition to slugs that aren't
+  in the managed steps while `onNextSlug` is provided
+
 ## [0.0.1] - 05-12-2019
 
 ### Added

--- a/src/orchestrator/Orchestrator.test.tsx
+++ b/src/orchestrator/Orchestrator.test.tsx
@@ -30,6 +30,7 @@ it("renders correctly with all props", async () => {
       steps={staticForm.steps}
       initialSlug={staticForm.steps[1].slug}
       manageStepTransitions={false}
+      provideDatabase={false}
       onNextStep={(): void => {}}
     />
   );


### PR DESCRIPTION
# What?

- Add `provideDatabase` to `Orchestrator`'s props to support manually wrapping
  steps with a `DatabaseProvider`
- Stop throwing an error when attempting to transition to slugs that aren't
  in the managed steps while `onNextSlug` is provided

# Why?

We want to be able to have pages outside of those managed by the `Orchestrator`. We're not permitting unmounting `DatabaseProvider`, so implementers need to all of their pages in one.

# Notes

It's crunch time, so I haven't written any tests beyond basic smoke tests.