### PR TITLE
Switch to using a read-write transaction when updating the data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 
 - Stopped throwing an error when attempting to transition to slugs that aren't
   in the managed steps while `onNextSlug` is provided
+- Changed to correctly using a read-write transition when persisting data to a
+  `Database`
 
 ## [0.0.1] - 05-12-2019
 

--- a/src/step/internal/Step.test.tsx
+++ b/src/step/internal/Step.test.tsx
@@ -206,6 +206,11 @@ it("persists data to the database when submitted", async () => {
   fireEvent.click(getByTestId("submit"));
 
   expect(transaction.spy).toHaveBeenCalledTimes(1);
+  expect(transaction.spy).toHaveBeenCalledWith(
+    ["testStore"],
+    transaction.spy.mock.calls[0][1],
+    "readwrite"
+  );
 
   await transaction.settle;
 
@@ -277,6 +282,11 @@ it("deletes the corresponding data from the database when submitted with the emp
   fireEvent.click(getByTestId("submit"));
 
   expect(transaction.spy).toHaveBeenCalledTimes(1);
+  expect(transaction.spy).toHaveBeenCalledWith(
+    ["testStore"],
+    transaction.spy.mock.calls[0][1],
+    "readwrite"
+  );
 
   await transaction.settle;
 

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { ComponentWrapper } from "../../component-wrapper/ComponentWrapper";
-import { Database } from "../../database/Database";
+import { Database, TransactionMode } from "../../database/Database";
 import {
   NamedSchema,
   Schema,
@@ -155,8 +155,10 @@ export class Step<
             storeName && array.indexOf(storeName) === index
         ) as StoreName[];
 
-      await database.transaction(storeNames, stores =>
-        this.persistValuesToDatabase(stores)
+      await database.transaction(
+        storeNames,
+        stores => this.persistValuesToDatabase(stores),
+        "readwrite" as TransactionMode
       );
     }
 


### PR DESCRIPTION
This fixes the `store.put` call rejection due to not having write permissions.