### PR TITLE
Release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.0.2] - 17-12-2019
+
 ### Changed
 
 - Added `provideDatabase` to `Orchestrator`'s props to support manually wrapping
@@ -37,5 +39,6 @@ and this project adheres to
 - `makeDatabase`, a Higher Order Component to make wrapping dynamic components
   more straightforward
 
-[unreleased]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.1...HEAD
+[unreleased]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/LBHackney-IT/remultiform/releases/tag/v0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,6 +2190,7 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3841,7 +3842,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -4017,6 +4019,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
       "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "nan": "^2.12.1",
@@ -4026,22 +4029,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -4050,12 +4057,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4064,32 +4073,38 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4097,22 +4112,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -4120,12 +4139,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -4141,6 +4162,7 @@
           "version": "7.1.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -4153,12 +4175,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -4167,6 +4191,7 @@
           "version": "3.0.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -4175,6 +4200,7 @@
           "version": "1.0.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -4183,17 +4209,20 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4201,12 +4230,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4214,12 +4245,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4229,6 +4262,7 @@
           "version": "1.3.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -4237,6 +4271,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4244,12 +4279,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -4260,6 +4297,7 @@
           "version": "0.14.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -4277,6 +4315,7 @@
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -4286,6 +4325,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -4293,12 +4333,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -4308,6 +4350,7 @@
           "version": "4.1.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -4318,17 +4361,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4336,17 +4382,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -4355,17 +4404,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -4376,7 +4428,8 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4384,6 +4437,7 @@
           "version": "2.3.6",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4398,6 +4452,7 @@
           "version": "2.7.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -4405,37 +4460,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4446,6 +4508,7 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4454,6 +4517,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4461,12 +4525,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -4480,12 +4546,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -4493,12 +4561,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6334,7 +6404,8 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -8803,6 +8874,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
       "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remultiform",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remultiform",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The React multipage form builder",
   "license": "MIT",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
### Changed

- Added `provideDatabase` to `Orchestrator`'s props to support manually wrapping
  steps with a `DatabaseProvider`

### Fixed

- Stopped throwing an error when attempting to transition to slugs that aren't
  in the managed steps while `onNextSlug` is provided
- Changed to correctly using a read-write transition when persisting data to a
  `Database`