### PR TITLE
Update the stored value when the database fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Connected the data fetched by `WrappedComponent` to the `Step`'s
+  representation of that data to prevent deleting values that are unchanged
+
 ## [0.0.2] - 17-12-2019
 
 ### Changed

--- a/src/component-wrapper/internal/WrappedComponent.test.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.test.tsx
@@ -122,6 +122,7 @@ it("renders correctly with a database context", async () => {
 
 it("fetches the stored value specified by the `databaseMap` when a database provided by context finishes opening", async () => {
   const get = spyOnDatabaseGet();
+  const onChange = jest.fn();
 
   const openPromise = Database.open<TestSchema>("testDBName", 1);
   const DBContext = new DatabaseContext(openPromise);
@@ -133,7 +134,11 @@ it("fetches the stored value specified by the `databaseMap` when a database prov
       <DatabaseProvider context={DBContext}>
         <DBContext.Consumer>
           {(database): JSX.Element => (
-            <WrappedComponent database={database} component={testComponent} />
+            <WrappedComponent
+              database={database}
+              component={testComponent}
+              onChange={onChange}
+            />
           )}
         </DBContext.Consumer>
       </DatabaseProvider>
@@ -144,6 +149,11 @@ it("fetches the stored value specified by the `databaseMap` when a database prov
   });
 
   expect(get.spy).toHaveBeenCalledTimes(1);
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(
+    `${testDatabaseMap.storeName}/${testDatabaseMap.key}`
+  );
 
   expect(component).toMatchInlineSnapshot(`
     <div>

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -206,6 +206,10 @@ export class WrappedComponent<
         stateUpdate.value = emptyValue;
       }
 
+      this.onValueChange(
+        stateUpdate.value as StoreValue<DBSchema["schema"], StoreName>
+      );
+
       // Clear the error if it was set.
       stateUpdate.error = undefined;
     } catch (err) {


### PR DESCRIPTION
# What?

We now call `onValueChange` when we do the fetch.

# Why?

Without this, `Step`'s representation of the component's value is the empty value, which means we will delete it from the database.