### PR TITLE
Make `DynamicComponent.emptyValue` required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to
 - Improved prop type inference for `StaticComponent`s
 - Removed the empty string from types that will never handle the artificial
   empty value
+- Made `emptyValue` required for `DynamicComponent`s
 
 ## [0.0.3] - 18-12-2019
 

--- a/src/__fixtures__/forms/dynamicForm.ts
+++ b/src/__fixtures__/forms/dynamicForm.ts
@@ -41,14 +41,15 @@ export const dynamicForm = {
             props: {
               content: "test content"
             },
+            defaultValue: "test default",
+            emptyValue: "",
             databaseMap: new ComponentDatabaseMap<
               DynamicFormSchema,
               "testStore"
             >({
               storeName: "testStore",
               key: 0
-            }),
-            defaultValue: "test default"
+            })
           })
         )
       ]
@@ -74,14 +75,15 @@ export const dynamicForm = {
             props: {
               content: "more test content"
             },
+            defaultValue: "test default",
+            emptyValue: "",
             databaseMap: new ComponentDatabaseMap<
               DynamicFormSchema,
               "testStore"
             >({
               storeName: "testStore",
               key: 1
-            }),
-            defaultValue: "test default"
+            })
           })
         )
       ]

--- a/src/component-wrapper/ComponentDatabaseMap.ts
+++ b/src/component-wrapper/ComponentDatabaseMap.ts
@@ -117,24 +117,16 @@ export class ComponentDatabaseMap<
       PropTypes.string.isRequired,
       PropTypes.number.isRequired
     ]).isRequired,
-    // We need to cast this because `PropTypes.array` doesn't know how to
-    // limit the number of elements in the array, as so creates the
-    // incompatible type of `(string | number | symbol)[]`.
+    // We need to cast this because `PropTypes.arrayOf` doesn't know how to
+    // limit the number of elements in the array, and so creates the
+    // incompatible type of `(string | symbol)[]`. This does mean the
+    // prop validatiion will let through some invalid `property`s.
     property: PropTypes.arrayOf(
       PropTypes.oneOfType([
         PropTypes.string.isRequired,
-        PropTypes.number.isRequired,
         PropTypes.symbol.isRequired
       ]).isRequired
-    ) as PropTypes.Requireable<
-      StoreValuePropertyPath<
-        StoreValue<
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          any,
-          string
-        >
-      >
-    >
+    ) as PropTypes.Requireable<[string] | [string, string | symbol]>
   });
 
   readonly storeName: StoreName;

--- a/src/component-wrapper/ComponentWrapper.test.ts
+++ b/src/component-wrapper/ComponentWrapper.test.ts
@@ -62,6 +62,7 @@ describe(".wrapDynamic()", () => {
           content: "test content"
         },
         defaultValue: "test default",
+        emptyValue: "test empty",
         databaseMap: new ComponentDatabaseMap<TestSchema, typeof storeName>({
           storeName,
           key: 0
@@ -101,6 +102,7 @@ describe("#key", () => {
           content: "test content"
         },
         defaultValue: "test default",
+        emptyValue: "test empty",
         databaseMap: new ComponentDatabaseMap<TestSchema, typeof storeName>({
           storeName,
           key: 0
@@ -189,7 +191,7 @@ describe("#defaultValue", () => {
 });
 
 describe("#emptyValue", () => {
-  it("is an empty string when wrapping a `StaticComponent`", () => {
+  it("is undefined when wrapping a `StaticComponent`", () => {
     const componentWrapper = ComponentWrapper.wrapStatic(
       new StaticComponent({
         key: "test-key",
@@ -200,7 +202,7 @@ describe("#emptyValue", () => {
       })
     );
 
-    expect(componentWrapper.emptyValue).toEqual("");
+    expect(componentWrapper.emptyValue).toBeUndefined();
   });
 
   it("matches the database map provided when wrapping a `DynamicComponent`", () => {

--- a/src/component-wrapper/ComponentWrapper.tsx
+++ b/src/component-wrapper/ComponentWrapper.tsx
@@ -18,7 +18,7 @@ export interface ComponentWrapperRenderProps<
   StoreName extends StoreNames<DBSchema["schema"]>
 > {
   database?: Database<DBSchema>;
-  onChange(value: "" | ComponentValue<DBSchema, StoreName>): void;
+  onChange(value: ComponentValue<DBSchema, StoreName>): void;
 }
 
 /**
@@ -53,7 +53,7 @@ export class ComponentWrapper<
       >
     >(ComponentDatabaseMap),
     defaultValue: PropTypes.any,
-    emptyValue: PropTypes.any.isRequired
+    emptyValue: PropTypes.any
   });
 
   /**
@@ -157,8 +157,11 @@ export class ComponentWrapper<
 
   /**
    * The value to consider as an empty input when updating the {@link Database}.
+   *
+   * If {@link ComponentWrapper.databaseMap} is defined, then willd also be
+   * defined.
    */
-  readonly emptyValue: "" | ComponentValue<DBSchema, StoreName>;
+  readonly emptyValue?: ComponentValue<DBSchema, StoreName> | null;
 
   /**
    * Do not use this directly. Use {@link ComponentWrapper.wrapStatic} or
@@ -179,7 +182,7 @@ export class ComponentWrapper<
     }) => boolean,
     databaseMap?: ComponentDatabaseMap<DBSchema, StoreName>,
     defaultValue?: ComponentValue<DBSchema, StoreName> | null,
-    emptyValue: "" | ComponentValue<DBSchema, StoreName> = ""
+    emptyValue?: ComponentValue<DBSchema, StoreName> | null
   ) {
     this.key = key;
     this.render = render;

--- a/src/component-wrapper/DynamicComponent.test.ts
+++ b/src/component-wrapper/DynamicComponent.test.ts
@@ -24,7 +24,8 @@ describe("#key", () => {
       key,
       Component: TestDynamicComponent,
       props: { content: "test content" },
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -43,7 +44,8 @@ describe("#Component", () => {
       key: "test-key",
       Component,
       props: { content: "test content" },
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -62,7 +64,8 @@ describe("#props", () => {
       key: "test-key",
       Component: TestDynamicComponent,
       props,
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -82,7 +85,8 @@ describe("#renderWhen", () => {
       Component: TestDynamicComponent,
       props: { content: "test content" },
       renderWhen,
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -97,7 +101,8 @@ describe("#renderWhen", () => {
       key: "test-key",
       Component: TestDynamicComponent,
       props: { content: "test content" },
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -119,7 +124,8 @@ describe("#databaseMap", () => {
       key: "test-key",
       Component: TestDynamicComponent,
       props: { content: "test content" },
-      defaultValue: "test value",
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
       databaseMap
     });
 
@@ -136,6 +142,7 @@ describe("#defaultValue", () => {
       Component: TestDynamicComponent,
       props: { content: "test content" },
       defaultValue,
+      emptyValue: "test empty value",
       databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
         storeName: "testStore",
         key: 0
@@ -163,20 +170,5 @@ describe("#emptyValue", () => {
     });
 
     expect(component.emptyValue).toEqual(emptyValue);
-  });
-
-  it("is an empty string when no `emptyValue` is provided to the constructor", () => {
-    const component = new DynamicComponent({
-      key: "test-key",
-      Component: TestDynamicComponent,
-      props: { content: "test content" },
-      databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
-        storeName: "testStore",
-        key: 0
-      }),
-      defaultValue: "test default value"
-    });
-
-    expect(component.emptyValue).toEqual("");
   });
 });

--- a/src/component-wrapper/DynamicComponent.ts
+++ b/src/component-wrapper/DynamicComponent.ts
@@ -27,7 +27,7 @@ export interface DynamicComponentControlledProps<Value> {
    * controlled component} pattern with
    * {@link DynamicComponentControlledProps.onValueChange}.
    */
-  value: "" | Value;
+  value: Value;
 
   /**
    * The callback to call when the component's value changes.
@@ -135,10 +135,10 @@ export interface DynamicComponentOptions<
   /**
    * The value representing an empty value for this component.
    *
-   * If you leave this unspecified, it will assume the empty value is an empty
-   * string.
+   * In order for React to manage a controlled component, the controlled prop
+   * must always be defined.
    */
-  emptyValue?: Value;
+  emptyValue: Value;
 }
 
 /**
@@ -242,7 +242,7 @@ export class DynamicComponent<
   }) => boolean;
   readonly databaseMap: ComponentDatabaseMap<DBSchema, StoreName>;
   readonly defaultValue: Value | null | undefined;
-  readonly emptyValue: "" | Value;
+  readonly emptyValue: Value;
 
   constructor(
     options: DynamicComponentOptions<
@@ -268,12 +268,9 @@ export class DynamicComponent<
     this.props = props;
     this.databaseMap = databaseMap;
     this.defaultValue = defaultValue;
+    this.emptyValue = emptyValue;
 
     this.renderWhen =
       renderWhen === undefined ? (): boolean => true : renderWhen;
-
-    // We need to do this to keep the component as a controlled component. The
-    // controlled prop must always be defined.
-    this.emptyValue = emptyValue === undefined ? "" : emptyValue;
   }
 }

--- a/src/component-wrapper/__mocks__/ComponentWrapper.tsx
+++ b/src/component-wrapper/__mocks__/ComponentWrapper.tsx
@@ -18,7 +18,7 @@ export interface ComponentWrapperRenderProps<
   StoreName extends StoreNames<DBSchema["schema"]>
 > {
   database?: Database<DBSchema>;
-  onChange(value: "" | ComponentValue<DBSchema, StoreName>): void;
+  onChange(value: ComponentValue<DBSchema, StoreName>): void;
 }
 
 export class ComponentWrapper<
@@ -93,7 +93,7 @@ export class ComponentWrapper<
     }) => boolean,
     databaseMap?: ComponentDatabaseMap<DBSchema, StoreName>,
     defaultValue?: ComponentValue<DBSchema, StoreName> | null,
-    emptyValue?: "" | ComponentValue<DBSchema, StoreName>
+    emptyValue?: ComponentValue<DBSchema, StoreName> | null
   ) {
     super(key, render, renderWhen, databaseMap, defaultValue, emptyValue);
   }

--- a/src/component-wrapper/internal/WrappedComponent.test.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.test.tsx
@@ -81,6 +81,7 @@ it("renders correctly with an undefined default value for the component", () => 
       content: "test content"
     },
     defaultValue: undefined as string | undefined,
+    emptyValue: "test empty",
     databaseMap: testDatabaseMap
   });
 
@@ -95,7 +96,7 @@ it("renders correctly with an undefined default value for the component", () => 
         data-testid="input"
         disabled={true}
         onChange={[Function]}
-        value=""
+        value="test empty"
       />
     </div>
   `);
@@ -215,7 +216,8 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
     key: "test-component",
     Component,
     props: {},
-    defaultValue: {},
+    defaultValue: {} as TestSchema["schema"]["anotherTestStore"]["value"]["a"],
+    emptyValue: {} as TestSchema["schema"]["anotherTestStore"]["value"]["a"],
     databaseMap
   });
 
@@ -269,6 +271,7 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
       content: "test content"
     },
     defaultValue: "test default value",
+    emptyValue: "test empty",
     databaseMap
   });
 
@@ -451,6 +454,7 @@ it("is disabled while the database is opening", async () => {
     Component: Tester,
     props: {},
     defaultValue: "test default",
+    emptyValue: "test empty",
     databaseMap: testDatabaseMap
   });
 
@@ -489,6 +493,7 @@ it("is disabled while fetching the stored value from the database", async () => 
     Component: Tester,
     props: {},
     defaultValue: "test default",
+    emptyValue: "test empty",
     databaseMap: testDatabaseMap
   });
 

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -45,7 +45,7 @@ export interface WrappedComponentProps<
     Value
   >;
 
-  onChange?: ((value: "" | Value) => void) | null;
+  onChange?: ((value: Value) => void) | null;
 }
 
 interface WrappedComponentState<
@@ -53,7 +53,7 @@ interface WrappedComponentState<
   StoreName extends StoreNames<DBSchema["schema"]>,
   Value extends ComponentValue<DBSchema, StoreName>
 > {
-  value: "" | Value;
+  value: Value;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any;
   isFetching: boolean;
@@ -227,7 +227,7 @@ export class WrappedComponent<
     this.setState(state => ({ ...state, ...stateUpdate }));
   }
 
-  private onValueChange(value: "" | Value): void {
+  private onValueChange(value: Value): void {
     if (this.isUnmounted) {
       return;
     }

--- a/src/step/internal/Step.test.tsx
+++ b/src/step/internal/Step.test.tsx
@@ -251,6 +251,7 @@ it("persists data to the database when submitted", async () => {
           content: "test content"
         },
         defaultValue: "test default value",
+        emptyValue: "test empty value",
         databaseMap
       })
     )
@@ -403,6 +404,7 @@ it("persists child property data to the database when submitted", async () => {
           content: "test content"
         },
         defaultValue: "test default value",
+        emptyValue: "test empty value",
         databaseMap
       })
     )


### PR DESCRIPTION
This requires also making it optional for `ComponentWrapper`s, as they no longer have a default value to set for them.

Having the extra `""` in the types was confusing and difficult to reason about. Making it required makes this easier to follow at the cost of some extra work for the user.