### PR TITLE
Stop attempting a transaction without data to persist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped trying to persist data in `Step`, when the step has no
+  `DynamicComponent`s
+
 ## [0.0.4] - 02-01-2020
 
 ### Added

--- a/src/__tests__/helpers/spies.ts
+++ b/src/__tests__/helpers/spies.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Database, TransactionMode } from "../../database/Database";
+import { Database } from "../../database/Database";
 import { OpenOptions } from "../../database/OpenOptions";
 import { Store, StoreMap } from "../../database/Store";
-import { NamedSchema, Schema } from "../../database/types";
+import { NamedSchema, Schema, TransactionMode } from "../../database/types";
 
 import { promiseToWaitForNextTick } from "./promise";
 

--- a/src/component-wrapper/ComponentDatabaseMap.ts
+++ b/src/component-wrapper/ComponentDatabaseMap.ts
@@ -2,11 +2,11 @@ import PropTypes from "prop-types";
 
 import {
   NamedSchema,
+  PickStoreValueProperties,
   Schema,
   StoreKey,
   StoreNames,
   StoreValue,
-  StoreValueProperties,
   StoreValuePropertyPath
 } from "../database/types";
 
@@ -19,13 +19,13 @@ type ComponentValueLevelOne<Value> = {
 // Value["a"]["b"]
 // This follows the same pattern as `StoreValuePropertyPathLevelTwo`.
 type ComponentValueLevelTwo<Value> = {
-  [K in keyof Value]: keyof StoreValueProperties<
+  [K in keyof Value]: keyof PickStoreValueProperties<
     NonNullable<Value[K]>
   > extends never // If `Value[K]` is a primitive...
     ? never // ...ignore it...
-    : StoreValueProperties<NonNullable<Value[K]>>[keyof StoreValueProperties<
+    : PickStoreValueProperties<
         NonNullable<Value[K]>
-      >]; // ...otherwise, include its children.
+      >[keyof PickStoreValueProperties<NonNullable<Value[K]>>]; // ...otherwise, include its children.
 }[keyof Value];
 
 /**
@@ -76,12 +76,14 @@ export interface ComponentDatabaseMapOptions<
    * Leave this blank to fetch and update the entire value directly, for
    * example, if you're storing primitives in this {@link Store}.
    */
-  property?: keyof StoreValueProperties<
+  property?: keyof PickStoreValueProperties<
     StoreValue<DBSchema["schema"], StoreName>
   > extends never
     ? never
     :
-        | keyof StoreValueProperties<StoreValue<DBSchema["schema"], StoreName>>
+        | keyof PickStoreValueProperties<
+            StoreValue<DBSchema["schema"], StoreName>
+          >
         | StoreValuePropertyPath<StoreValue<DBSchema["schema"], StoreName>>;
 }
 

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -3,12 +3,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { Database } from "../../database/Database";
-import {
-  NamedSchema,
-  Schema,
-  StoreNames,
-  StoreValueProperties
-} from "../../database/types";
+import { NamedSchema, Schema, StoreNames } from "../../database/types";
 
 import { ComponentDatabaseMap, ComponentValue } from "../ComponentDatabaseMap";
 import {
@@ -247,15 +242,19 @@ export class WrappedComponent<
   ): Promise<Value | undefined> {
     const { storeName, key, property } = databaseMap;
 
-    let value = (await database.get(storeName, key)) as Value | undefined;
+    const storedValue = await database.get(storeName, key);
+
+    if (storedValue === undefined) {
+      return undefined;
+    }
+
+    let value = storedValue as Value;
 
     if (property) {
       const propertyKeys = [...property] as typeof property;
 
       while (propertyKeys.length > 0 && value !== undefined) {
-        const k = (propertyKeys.shift() as unknown) as keyof StoreValueProperties<
-          Value
-        >;
+        const k = propertyKeys.shift() as keyof Value;
 
         value = (value[k] as unknown) as Value;
       }

--- a/src/component-wrapper/makeDynamic.tsx
+++ b/src/component-wrapper/makeDynamic.tsx
@@ -27,17 +27,17 @@ export interface MakeDynamicPropMap<PropsToMap> {
   /**
    * The name of the prop on the wrapped component to map `value` to.
    */
-  value: keyof PropsToMap;
+  value: keyof PropsToMap & string;
 
   /**
    * The name of the prop on the wrapped component to map `onValueChange` to.
    */
-  onValueChange: keyof PropsToMap;
+  onValueChange: keyof PropsToMap & string;
 
   /**
    * The name of the prop on the wrapped component to map `disabled` to.
    */
-  disabled: keyof PropsToMap;
+  disabled: keyof PropsToMap & string;
 }
 
 /**
@@ -182,13 +182,8 @@ export const makeDynamic = <
 
     if (typeof Component === "string") {
       const IntrinsicElement = Component as keyof JSX.IntrinsicElements;
-      // Infering the type of the React props acceptable for any possible
-      // `JSX.IntrinsicElements` is Hard. The type of this never leaves this
-      // scope, so we cheat, given that the author is confident about the types
-      // actually matching, whatever TypeScript says.
-      const intrinsicElementProps = mappedProps as {};
 
-      return <IntrinsicElement {...intrinsicElementProps} />;
+      return <IntrinsicElement {...mappedProps} />;
     } else {
       return <Component {...mappedProps} />;
     }
@@ -198,10 +193,9 @@ export const makeDynamic = <
     const IntrinsicElement = Component as keyof JSX.IntrinsicElements;
 
     Dynamic.displayName = `makeDynamic(${IntrinsicElement})`;
-
-    // We don't know the type of `Value` at runtime to use for the proptypes,
-    // so we allow `any`.
-    Dynamic.propTypes = DynamicComponent.controlledPropTypes<Value>(
+    Dynamic.propTypes = DynamicComponent.controlledPropTypes(
+      // As this is an intrinsic element, we don't know what type `value` will
+      // be at runtime.
       PropTypes.any.isRequired
     ) as React.WeakValidationMap<DynamicProps>;
   } else {

--- a/src/database/Database.test.ts
+++ b/src/database/Database.test.ts
@@ -6,8 +6,8 @@ import { expectPromise } from "../__tests__/helpers/expect";
 import { promiseToWaitForNextTick } from "../__tests__/helpers/promise";
 import { spyOnConsoleError } from "../__tests__/helpers/spies";
 
-import { Database, TransactionMode } from "./Database";
-import { NamedSchema } from "./types";
+import { Database } from "./Database";
+import { NamedSchema, TransactionMode } from "./types";
 
 const testDBName = "databaseTestDB";
 const testStoreName = "testStore";

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -9,15 +9,14 @@ import { wrapTransaction } from "./internal/wrapTransaction";
 
 import { OpenOptions } from "./OpenOptions";
 import { StoreMap } from "./Store";
-import { NamedSchema, Schema, StoreKey, StoreNames, StoreValue } from "./types";
-
-/**
- * Possible modes for transactions created by {@link Database.transaction}.
- */
-export enum TransactionMode {
-  ReadOnly = "readonly",
-  ReadWrite = "readwrite"
-}
+import {
+  NamedSchema,
+  Schema,
+  StoreKey,
+  StoreNames,
+  StoreValue,
+  TransactionMode
+} from "./types";
 
 /**
  * A wrapper for an IndexedDB connection.

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -18,7 +18,7 @@ type StorePropertyTypeProperties =
 /**
  * The type `T` without its inherent primitive prototype properties.
  */
-export type StoreValueProperties<T> = Omit<T, StorePropertyTypeProperties>;
+export type PickStoreValueProperties<T> = Omit<T, StorePropertyTypeProperties>;
 
 /**
  * The type of a possible value in a {@link StoreSchema}.
@@ -152,21 +152,23 @@ export type StoreValue<
 // ["a"] | ["z"]
 // This follows the same pattern as `ComponentValueLevelOne`.
 type StoreValuePropertyPathLevelOne<Value extends {}> = {
-  [K in keyof StoreValueProperties<Value>]: [K];
-}[keyof StoreValueProperties<Value>];
+  [K in keyof PickStoreValueProperties<Value>]: [K];
+}[keyof PickStoreValueProperties<Value>];
 
 // ["a", "b"] | ["z", "y"]
 // This follows the same pattern as `ComponentValueLevelTwo`.
 type StoreValuePropertyPathLevelTwo<Value extends {}> = {
-  [K in keyof StoreValueProperties<Value>]: keyof StoreValueProperties<
-    NonNullable<StoreValueProperties<Value>[K]>
+  [K in keyof PickStoreValueProperties<Value>]: keyof PickStoreValueProperties<
+    NonNullable<PickStoreValueProperties<Value>[K]>
   > extends never // If `Value[K]` is a primitive...
     ? never // ...ignore it...
     : [
         K,
-        keyof StoreValueProperties<NonNullable<StoreValueProperties<Value>[K]>>
+        keyof PickStoreValueProperties<
+          NonNullable<PickStoreValueProperties<Value>[K]>
+        >
       ]; // ...otherwise, allow referencing its children.
-}[keyof StoreValueProperties<Value>];
+}[keyof PickStoreValueProperties<Value>];
 
 /**
  * The type describing the "path" to a deep property of a {@link StoreValue}.
@@ -208,3 +210,11 @@ export type Transaction<
   DBSchema extends Schema,
   TxStoreNames extends StoreNames<DBSchema>[] = StoreNames<DBSchema>[]
 > = IDBPTransaction<DBSchema, TxStoreNames>;
+
+/**
+ * Possible modes for transactions created by {@link Database.transaction}.
+ */
+export enum TransactionMode {
+  ReadOnly = "readonly",
+  ReadWrite = "readwrite"
+}

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -175,11 +175,13 @@ export class Step<
             array.indexOf(storeName) === index
         ) as StoreName[];
 
-      await database.transaction(
-        storeNames,
-        stores => this.persistValuesToDatabase(stores),
-        TransactionMode.ReadWrite
-      );
+      if (storeNames.length > 0) {
+        await database.transaction(
+          storeNames,
+          stores => this.persistValuesToDatabase(stores),
+          TransactionMode.ReadWrite
+        );
+      }
     }
 
     if (afterSubmit) {

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -7,14 +7,16 @@ import {
   ComponentValue
 } from "../../component-wrapper/ComponentDatabaseMap";
 import { ComponentWrapper } from "../../component-wrapper/ComponentWrapper";
-import { Database, TransactionMode } from "../../database/Database";
+import { Database } from "../../database/Database";
 import { Store, StoreMap } from "../../database/Store";
 import {
   NamedSchema,
+  PickStoreValueProperties,
   Schema,
   StoreNames,
   StoreValue,
-  StoreValueProperties
+  StoreValuePropertyPath,
+  TransactionMode
 } from "../../database/types";
 import { DatabaseContext } from "../../database-context/DatabaseContext";
 
@@ -168,13 +170,15 @@ export class Step<
         .map(({ databaseMap }) => databaseMap && databaseMap.storeName)
         .filter(
           (storeName, index, array) =>
-            storeName && array.indexOf(storeName) === index
+            storeName &&
+            // Find unique `storeName`s:
+            array.indexOf(storeName) === index
         ) as StoreName[];
 
       await database.transaction(
         storeNames,
         stores => this.persistValuesToDatabase(stores),
-        "readwrite" as TransactionMode
+        TransactionMode.ReadWrite
       );
     }
 
@@ -191,23 +195,33 @@ export class Step<
 
     for (const { key, databaseMap, emptyValue } of componentWrappers) {
       if (databaseMap) {
-        // If `databaseMap` is defined, then `emptyValue` will also be
-        // defined.
-        const empty = emptyValue as ComponentValue<DBSchema, StoreName>;
         const { storeName, property } = databaseMap;
 
         const store = stores[storeName];
 
-        // If `databaseMap` is defined, then the component's value will also be
-        // defined.
-        const value = componentValues[key] as ComponentValue<
-          DBSchema,
-          StoreName
-        >;
-
         if (property) {
+          // If `databaseMap` is defined, then `emptyValue` will also be
+          // defined.
+          const empty = emptyValue as ComponentValue<DBSchema, StoreName>;
+          // If `databaseMap` is defined, then the component's value will also
+          // be defined.
+          const value = componentValues[key] as ComponentValue<
+            DBSchema,
+            StoreName
+          >;
+
           await this.persistProperty(store, databaseMap, value, empty);
         } else {
+          // If `databaseMap` is defined, then `emptyValue` will also be
+          // defined.
+          const empty = emptyValue as StoreValue<DBSchema["schema"], StoreName>;
+          // If `databaseMap` is defined, then the component's value will also
+          // be defined.
+          const value = componentValues[key] as StoreValue<
+            DBSchema["schema"],
+            StoreName
+          >;
+
           await this.persistValue(store, databaseMap, value, empty);
         }
       }
@@ -223,61 +237,59 @@ export class Step<
     const { key, property } = databaseMap;
 
     if (!property) {
-      await this.persistValue(store, databaseMap, propertyValue, emptyValue);
+      await this.persistValue(
+        store,
+        databaseMap,
+        propertyValue as StoreValue<DBSchema["schema"], StoreName>,
+        emptyValue as StoreValue<DBSchema["schema"], StoreName>
+      );
 
       return;
     }
 
-    type SValue = StoreValue<DBSchema["schema"], StoreName> & {};
-    type ChildValue = StoreValueProperties<
-      {
-        [K in keyof StoreValueProperties<SValue>]: StoreValueProperties<
-          SValue
-        >[K];
-      }[keyof StoreValueProperties<SValue>]
-    >;
+    const storedValue = await store.get(key);
 
-    const originalValue = (await store.get(key)) as SValue | undefined;
-
-    if (originalValue === undefined && propertyValue === emptyValue) {
+    if (storedValue === undefined && propertyValue === emptyValue) {
       // We would clear the property value from the store if there was
       // anything to clear, but there isn't, so we do nothing and early exit.
       return;
     }
 
     const value =
-      originalValue === undefined
+      storedValue === undefined
         ? // Using an empty object means the schema might not be correct, as the
           // store may end up with partial data. There's not much we do to
           // detect or enforce this at runtime, as the schema only exists in
           // type land, but we should consider requiring the user to specify a
           // base value to use in this case as part of setting up the database.
-          ({} as SValue)
-        : originalValue;
+          ({} as StoreValue<DBSchema["schema"], StoreName>)
+        : storedValue;
 
-    const propertyKeys = [...property] as typeof property;
+    const propertyKeys = [...property] as StoreValuePropertyPath<
+      StoreValue<DBSchema["schema"], StoreName>
+    >;
+
     const k0 = propertyKeys[0];
 
     if (propertyKeys.length > 1) {
-      const child = (value[k0] === undefined ? {} : value[k0]) as ChildValue;
-      const k1 = propertyKeys[1] as keyof ChildValue;
+      const child =
+        value[k0] === undefined ? ({} as typeof value[typeof k0]) : value[k0];
+      const k1 = propertyKeys[1] as keyof PickStoreValueProperties<
+        typeof child
+      >;
 
       if (propertyValue === emptyValue) {
         delete child[k1];
       } else {
-        child[
-          k1
-        ] = (propertyValue as unknown) as ChildValue[keyof StoreValueProperties<
-          ChildValue
-        >];
+        child[k1] = propertyValue as typeof child[typeof k1];
       }
 
-      value[k0] = child as SValue[keyof StoreValueProperties<SValue>];
+      value[k0] = child;
     } else {
       if (propertyValue === emptyValue) {
         delete value[k0];
       } else {
-        value[k0] = propertyValue as SValue[keyof StoreValueProperties<SValue>];
+        value[k0] = propertyValue as typeof value[typeof k0];
       }
     }
 
@@ -287,15 +299,15 @@ export class Step<
   private async persistValue(
     store: Store<DBSchema["schema"], StoreName[], StoreName>,
     databaseMap: ComponentDatabaseMap<DBSchema, StoreName>,
-    value: ComponentValue<DBSchema, StoreName>,
-    emptyValue: ComponentValue<DBSchema, StoreName>
+    value: StoreValue<DBSchema["schema"], StoreName>,
+    emptyValue: StoreValue<DBSchema["schema"], StoreName>
   ): Promise<void> {
     const { key } = databaseMap;
 
     if (value === emptyValue) {
       await store.delete(key);
     } else {
-      await store.put(key, value as StoreValue<DBSchema["schema"], StoreName>);
+      await store.put(key, value);
     }
   }
 }


### PR DESCRIPTION
If we don't have any store names to open the transaction on, we only have static components, which have no variable data.

This includes #475 to avoid the inevitable merge conflict.