### PR TITLE
MT3-504 #done Add the ability to specify dynamic database keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Support for steps to navigate to different slugs depending on the state of the
   step
+- Support for specifying dynamic keys for `ComponentDatabaseMap`s
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Support for steps to navigate to different slugs depending on the state of the
   step
 
+### Changed
+
+- Simplifed some generic types
+
 ### Fixed
 
 - Stopped trying to persist data in `Step`, when the step has no

--- a/src/__fixtures__/forms/dynamicForm.ts
+++ b/src/__fixtures__/forms/dynamicForm.ts
@@ -28,7 +28,7 @@ export const dynamicForm = {
         return SimpleSubmit;
       },
       componentWrappers: [
-        ComponentWrapper.wrapStatic<DynamicFormSchema>(
+        ComponentWrapper.wrapStatic<DynamicFormSchema, "testStore">(
           new StaticComponent({
             key: "test-img",
             Component: "img",
@@ -64,7 +64,7 @@ export const dynamicForm = {
         return SimpleSubmit;
       },
       componentWrappers: [
-        ComponentWrapper.wrapStatic<DynamicFormSchema>(
+        ComponentWrapper.wrapStatic<DynamicFormSchema, "testStore">(
           new StaticComponent({
             key: "test-img-2",
             Component: "img",

--- a/src/component-wrapper/ComponentDatabaseMap.ts
+++ b/src/component-wrapper/ComponentDatabaseMap.ts
@@ -7,26 +7,23 @@ import {
   StoreKey,
   StoreNames,
   StoreValue,
-  StoreValuePropertyPath
+  StoreValuePropertyPath,
+  StoreValuePropertyPathLevelOne,
+  StoreValuePropertyPathLevelTwo
 } from "../database/types";
 
 // Value["a"]
-// This follows the same pattern as `StoreValuePropertyPathLevelOne`.
 type ComponentValueLevelOne<Value> = {
-  [K in keyof Value]: Value[K];
-}[keyof Value];
+  [K in StoreValuePropertyPathLevelOne<Value>[0]]: Value[K];
+}[StoreValuePropertyPathLevelOne<Value>[0]];
 
 // Value["a"]["b"]
-// This follows the same pattern as `StoreValuePropertyPathLevelTwo`.
 type ComponentValueLevelTwo<Value> = {
-  [K in keyof Value]: keyof PickStoreValueProperties<
-    NonNullable<Value[K]>
-  > extends never // If `Value[K]` is a primitive...
-    ? never // ...ignore it...
-    : PickStoreValueProperties<
-        NonNullable<Value[K]>
-      >[keyof PickStoreValueProperties<NonNullable<Value[K]>>]; // ...otherwise, include its children.
-}[keyof Value];
+  [K in StoreValuePropertyPathLevelTwo<Value>[0]]: {
+    [J in StoreValuePropertyPathLevelTwo<Value>[1] &
+      keyof Value[K]]: Value[K][J];
+  }[StoreValuePropertyPathLevelTwo<Value>[1] & keyof Value[K]];
+}[StoreValuePropertyPathLevelTwo<Value>[0]];
 
 /**
  * The possible values a {@link ComponentDatabaseMap} could map to.

--- a/src/component-wrapper/ComponentWrapper.tsx
+++ b/src/component-wrapper/ComponentWrapper.tsx
@@ -41,15 +41,17 @@ export class ComponentWrapper<
    * The proptype validator for a {@link ComponentWrapper}.
    */
   static readonly propType: PropTypes.Requireable<
-    ComponentWrapper<NamedSchema<string, number, Schema>, StoreNames<Schema>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ComponentWrapper<NamedSchema<string, number, any>, string>
   > = PropTypes.exact({
     key: PropTypes.string.isRequired,
     render: PropTypes.func.isRequired,
     renderWhen: PropTypes.func.isRequired,
     databaseMap: PropTypes.instanceOf<
       ComponentDatabaseMap<
-        NamedSchema<string, number, Schema>,
-        StoreNames<Schema>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        NamedSchema<string, number, any>,
+        string
       >
     >(ComponentDatabaseMap),
     defaultValue: PropTypes.any,

--- a/src/component-wrapper/ComponentWrapper.tsx
+++ b/src/component-wrapper/ComponentWrapper.tsx
@@ -7,7 +7,7 @@ import { NamedSchema, Schema, StoreNames } from "../database/types";
 import { WrappedComponent } from "./internal/WrappedComponent";
 
 import { ComponentDatabaseMap, ComponentValue } from "./ComponentDatabaseMap";
-import { DynamicComponentType, DynamicComponent } from "./DynamicComponent";
+import { DynamicComponent } from "./DynamicComponent";
 import { StaticComponent } from "./StaticComponent";
 
 /**
@@ -15,10 +15,11 @@ import { StaticComponent } from "./StaticComponent";
  */
 export interface ComponentWrapperRenderProps<
   DBSchema extends NamedSchema<string, number, Schema>,
-  StoreName extends StoreNames<DBSchema["schema"]>
+  StoreName extends StoreNames<DBSchema["schema"]>,
+  Value extends ComponentValue<DBSchema, StoreName>
 > {
   database?: Database<DBSchema>;
-  onChange(value: ComponentValue<DBSchema, StoreName>): void;
+  onChange(value: Value): void;
 }
 
 /**
@@ -35,14 +36,15 @@ export interface ComponentWrapperRenderProps<
 // it. This gives us strong typing with little effort for the user.
 export class ComponentWrapper<
   DBSchema extends NamedSchema<string, number, Schema>,
-  StoreName extends StoreNames<DBSchema["schema"]>
+  StoreName extends StoreNames<DBSchema["schema"]>,
+  Value extends ComponentValue<DBSchema, StoreName>
 > {
   /**
    * The proptype validator for a {@link ComponentWrapper}.
    */
   static readonly propType: PropTypes.Requireable<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ComponentWrapper<NamedSchema<string, number, any>, string>
+    ComponentWrapper<NamedSchema<string, number, any>, string, any>
   > = PropTypes.exact({
     key: PropTypes.string.isRequired,
     render: PropTypes.func.isRequired,
@@ -67,9 +69,18 @@ export class ComponentWrapper<
    * It's possible to infer this if {@link StaticComponent.renderWhen} is
    * implemented on `component`.
    */
-  static wrapStatic<DBSchema extends NamedSchema<string, number, Schema>>(
+  static wrapStatic<
+    DBSchema extends NamedSchema<string, number, Schema>,
+    StoreName extends StoreNames<DBSchema["schema"]> = StoreNames<
+      DBSchema["schema"]
+    >,
+    Value extends ComponentValue<DBSchema, StoreName> = ComponentValue<
+      DBSchema,
+      StoreName
+    >
+  >(
     component: StaticComponent<React.ElementType, DBSchema>
-  ): ComponentWrapper<DBSchema, StoreNames<DBSchema["schema"]>> {
+  ): ComponentWrapper<DBSchema, StoreName, Value> {
     const { key, Component, props, renderWhen } = component;
 
     return new ComponentWrapper(
@@ -87,19 +98,13 @@ export class ComponentWrapper<
    * infered from the {@link DynamicComponent} passed in.
    */
   static wrapDynamic<
-    Props,
+    Props extends {},
     DBSchema extends NamedSchema<string, number, Schema>,
     StoreName extends StoreNames<DBSchema["schema"]>,
     Value extends ComponentValue<DBSchema, StoreName>
   >(
-    component: DynamicComponent<
-      DynamicComponentType<Props, Value>,
-      Props,
-      DBSchema,
-      StoreName,
-      Value
-    >
-  ): ComponentWrapper<DBSchema, StoreName> {
+    component: DynamicComponent<Props, DBSchema, StoreName, Value>
+  ): ComponentWrapper<DBSchema, StoreName, Value> {
     const {
       key,
       renderWhen,
@@ -109,7 +114,7 @@ export class ComponentWrapper<
     } = component;
 
     const render = (
-      props: ComponentWrapperRenderProps<DBSchema, StoreName>
+      props: ComponentWrapperRenderProps<DBSchema, StoreName, Value>
     ): JSX.Element => (
       <WrappedComponent key={key} component={component} {...props} />
     );
@@ -130,7 +135,7 @@ export class ComponentWrapper<
    * A function to render an instance of the component.
    */
   readonly render: (
-    props: ComponentWrapperRenderProps<DBSchema, StoreName>
+    props: ComponentWrapperRenderProps<DBSchema, StoreName, Value>
   ) => JSX.Element;
 
   /**
@@ -155,7 +160,7 @@ export class ComponentWrapper<
    * The optional default value to store in the {@link Database} if the
    * component hasn't been changed by the user.
    */
-  readonly defaultValue?: ComponentValue<DBSchema, StoreName> | null;
+  readonly defaultValue?: Value | null;
 
   /**
    * The value to consider as an empty input when updating the {@link Database}.
@@ -163,7 +168,7 @@ export class ComponentWrapper<
    * If {@link ComponentWrapper.databaseMap} is defined, then willd also be
    * defined.
    */
-  readonly emptyValue?: ComponentValue<DBSchema, StoreName> | null;
+  readonly emptyValue?: Value | null;
 
   /**
    * Do not use this directly. Use {@link ComponentWrapper.wrapStatic} or
@@ -175,7 +180,7 @@ export class ComponentWrapper<
   constructor(
     key: string,
     render: (
-      props: ComponentWrapperRenderProps<DBSchema, StoreName>
+      props: ComponentWrapperRenderProps<DBSchema, StoreName, Value>
     ) => JSX.Element,
     renderWhen: (stepValues: {
       [key: string]:
@@ -183,8 +188,8 @@ export class ComponentWrapper<
         | undefined;
     }) => boolean,
     databaseMap?: ComponentDatabaseMap<DBSchema, StoreName>,
-    defaultValue?: ComponentValue<DBSchema, StoreName> | null,
-    emptyValue?: ComponentValue<DBSchema, StoreName> | null
+    defaultValue?: Value | null,
+    emptyValue?: Value | null
   ) {
     this.key = key;
     this.render = render;

--- a/src/component-wrapper/DynamicComponent.ts
+++ b/src/component-wrapper/DynamicComponent.ts
@@ -61,7 +61,7 @@ export interface DynamicComponentControlledProps<Value> {
  * @typeparam Value - The {@link ComponentValue} of the value or value property
  * this component represents in the {@link Database}.
  */
-export type DynamicComponentType<Props, Value> = React.ComponentType<
+export type DynamicComponentType<Props extends {}, Value> = React.ComponentType<
   Props & DynamicComponentControlledProps<Value>
 >;
 
@@ -69,8 +69,7 @@ export type DynamicComponentType<Props, Value> = React.ComponentType<
  * The options for {@link DynamicComponent}.
  */
 export interface DynamicComponentOptions<
-  ComponentType extends DynamicComponentType<Props, Value>,
-  Props,
+  Props extends {},
   DBSchema extends NamedSchema<string, number, Schema>,
   StoreName extends StoreNames<DBSchema["schema"]>,
   Value extends ComponentValue<DBSchema, StoreName>
@@ -88,7 +87,7 @@ export interface DynamicComponentOptions<
    *
    * Pass static prop values via {@link DynamicComponentOptions.props}.
    */
-  Component: ComponentType;
+  Component: DynamicComponentType<Props, Value>;
 
   /**
    * The static props to pass to {@link DynamicComponentOptions.Component}.
@@ -177,8 +176,7 @@ export interface DynamicComponentOptions<
  * ```
  */
 export class DynamicComponent<
-  ComponentType extends DynamicComponentType<Props, Value>,
-  Props,
+  Props extends {},
   DBSchema extends NamedSchema<string, number, Schema>,
   StoreName extends StoreNames<DBSchema["schema"]>,
   Value extends ComponentValue<DBSchema, StoreName>
@@ -188,19 +186,12 @@ export class DynamicComponent<
    */
   static propType: PropTypes.Requireable<
     DynamicComponent<
-      DynamicComponentType<
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        any,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ComponentValue<NamedSchema<string, number, any>, string>
-      >,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      any,
+      {},
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       NamedSchema<string, number, any>,
       string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ComponentValue<NamedSchema<string, number, any>, string>
+      any
     >
   > = PropTypes.exact({
     key: PropTypes.string.isRequired,
@@ -233,7 +224,7 @@ export class DynamicComponent<
   }
 
   readonly key: string;
-  readonly Component: ComponentType;
+  readonly Component: DynamicComponentType<Props, Value>;
   readonly props: Props;
   readonly renderWhen: (stepValues: {
     [key: string]:
@@ -245,13 +236,7 @@ export class DynamicComponent<
   readonly emptyValue: Value;
 
   constructor(
-    options: DynamicComponentOptions<
-      ComponentType,
-      Props,
-      DBSchema,
-      StoreName,
-      Value
-    >
+    options: DynamicComponentOptions<Props, DBSchema, StoreName, Value>
   ) {
     const {
       key,

--- a/src/component-wrapper/__mocks__/ComponentWrapper.tsx
+++ b/src/component-wrapper/__mocks__/ComponentWrapper.tsx
@@ -4,7 +4,7 @@ import { Database } from "../../database/Database";
 import { NamedSchema, Schema, StoreNames } from "../../database/types";
 
 import { ComponentDatabaseMap, ComponentValue } from "../ComponentDatabaseMap";
-import { DynamicComponentType, DynamicComponent } from "../DynamicComponent";
+import { DynamicComponent } from "../DynamicComponent";
 import { StaticComponent } from "../StaticComponent";
 
 const { ComponentWrapper: ActualComponentWrapper } = jest.requireActual(
@@ -25,9 +25,14 @@ export class ComponentWrapper<
   DBSchema extends NamedSchema<string, number, Schema>,
   StoreName extends StoreNames<DBSchema["schema"]>
 > extends ActualComponentWrapper<DBSchema, StoreName> {
-  static wrapStatic<DBSchema extends NamedSchema<string, number, Schema>>(
+  static wrapStatic<
+    DBSchema extends NamedSchema<string, number, Schema>,
+    StoreName extends StoreNames<DBSchema["schema"]> = StoreNames<
+      DBSchema["schema"]
+    >
+  >(
     component: StaticComponent<React.ElementType, DBSchema>
-  ): ComponentWrapper<DBSchema, StoreNames<DBSchema["schema"]>> {
+  ): ComponentWrapper<DBSchema, StoreName> {
     const { key, Component, renderWhen } = component;
 
     return new ComponentWrapper(
@@ -45,18 +50,12 @@ export class ComponentWrapper<
   }
 
   static wrapDynamic<
-    Props,
+    Props extends {},
     DBSchema extends NamedSchema<string, number, Schema>,
     StoreName extends StoreNames<DBSchema["schema"]>,
     Value extends ComponentValue<DBSchema, StoreName>
   >(
-    component: DynamicComponent<
-      DynamicComponentType<Props, Value>,
-      Props,
-      DBSchema,
-      StoreName,
-      Value
-    >
+    component: DynamicComponent<Props, DBSchema, StoreName, Value>
   ): ComponentWrapper<DBSchema, StoreName> {
     const {
       key,

--- a/src/component-wrapper/internal/WrappedComponent.test.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.test.tsx
@@ -33,7 +33,7 @@ type TestSchema = NamedSchema<
     anotherTestStore: {
       key: number;
       value: {
-        a?: { value?: string };
+        a: { value: string };
       };
     };
   }
@@ -216,8 +216,8 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
     key: "test-component",
     Component,
     props: {},
-    defaultValue: {} as TestSchema["schema"]["anotherTestStore"]["value"]["a"],
-    emptyValue: {} as TestSchema["schema"]["anotherTestStore"]["value"]["a"],
+    defaultValue: { value: "" },
+    emptyValue: { value: "" },
     databaseMap
   });
 
@@ -344,9 +344,9 @@ it("uses the empty value before it fetches from the database", async () => {
       </div>
       <input
         data-testid="input"
-        disabled={false}
+        disabled={true}
         onChange={[Function]}
-        value="testStore/0"
+        value="test empty"
       />
     </div>
   `);

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -3,44 +3,29 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { Database } from "../../database/Database";
-import { NamedSchema, Schema, StoreNames } from "../../database/types";
+import {
+  NamedSchema,
+  Schema,
+  StoreNames,
+  StoreValuePropertyPathLevelTwo,
+  StoreValuePropertyPathLevelOne
+} from "../../database/types";
 
 import { ComponentDatabaseMap, ComponentValue } from "../ComponentDatabaseMap";
 import {
   DynamicComponent,
-  DynamicComponentControlledProps,
-  DynamicComponentType
+  DynamicComponentControlledProps
 } from "../DynamicComponent";
 
-/**
- * The proptypes for {@link WrappedComponent}.
- */
 export interface WrappedComponentProps<
-  Props,
+  Props extends {},
   DBSchema extends NamedSchema<string, number, Schema>,
   StoreName extends StoreNames<DBSchema["schema"]>,
   Value extends ComponentValue<DBSchema, StoreName>
 > {
-  /**
-   * An open {@link Database}.
-   *
-   * This is usually provided by a {@link DatabaseContext.Consumer} and is
-   * optional to allow waiting for {@link Database.open} to settle.
-   */
-  database?: Database<DBSchema> | null;
-
-  /**
-   * The {@link DynamicComponent} to wrap.
-   */
-  component: DynamicComponent<
-    DynamicComponentType<Props, Value>,
-    Props,
-    DBSchema,
-    StoreName,
-    Value
-  >;
-
+  component: DynamicComponent<Props, DBSchema, StoreName, Value>;
   onChange?: ((value: Value) => void) | null;
+  database?: Database<DBSchema> | null;
 }
 
 interface WrappedComponentState<
@@ -68,7 +53,7 @@ interface WrappedComponentState<
  * doesn't get out of sync.
  */
 export class WrappedComponent<
-  Props,
+  Props extends {},
   DBSchema extends NamedSchema<string, number, Schema>,
   StoreName extends StoreNames<DBSchema["schema"]>,
   Value extends ComponentValue<DBSchema, StoreName>
@@ -79,18 +64,17 @@ export class WrappedComponent<
 > {
   static propTypes: PropTypes.ValidationMap<
     WrappedComponentProps<
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      any,
+      {},
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       NamedSchema<string, number, any>,
       string,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ComponentValue<NamedSchema<string, number, any>, string>
+      any
     >
   > = {
-    database: PropTypes.instanceOf(Database),
     component: DynamicComponent.propType.isRequired,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    database: PropTypes.instanceOf(Database)
   };
 
   /**
@@ -248,18 +232,27 @@ export class WrappedComponent<
       return undefined;
     }
 
-    let value = storedValue as Value;
+    let value = storedValue as ComponentValue<DBSchema, StoreName>;
 
     if (property) {
-      const propertyKeys = [...property] as typeof property;
+      if (property.length > 0) {
+        const k = property[0] as StoreValuePropertyPathLevelOne<
+          ComponentValue<DBSchema, StoreName>
+        >[0];
 
-      while (propertyKeys.length > 0 && value !== undefined) {
-        const k = propertyKeys.shift() as keyof Value;
+        value = value[k] as ComponentValue<DBSchema, StoreName>;
+      }
 
-        value = (value[k] as unknown) as Value;
+      if (property.length > 1) {
+        const k = property[1] as StoreValuePropertyPathLevelTwo<
+          ComponentValue<DBSchema, StoreName>
+        >[1];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value = (value as any)[k] as ComponentValue<DBSchema, StoreName>;
       }
     }
 
-    return value;
+    return value as Value;
   }
 }

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -224,9 +224,15 @@ export class WrappedComponent<
     database: Database<DBSchema>,
     databaseMap: ComponentDatabaseMap<DBSchema, StoreName>
   ): Promise<Value | undefined> {
-    const { storeName, key, property } = databaseMap;
+    const { storeName, property } = databaseMap;
 
-    const storedValue = await database.get(storeName, key);
+    const storeKey = await databaseMap.getKey(database);
+
+    if (storeKey === undefined) {
+      return undefined;
+    }
+
+    const storedValue = await database.get(storeName, storeKey);
 
     if (storedValue === undefined) {
       return undefined;

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -149,15 +149,19 @@ export type StoreValue<
   StoreName extends StoreNames<DBSchema>
 > = DBSchema[StoreName]["value"];
 
+/**
+ * @ignore
+ */
 // ["a"] | ["z"]
-// This follows the same pattern as `ComponentValueLevelOne`.
-type StoreValuePropertyPathLevelOne<Value extends {}> = {
+export type StoreValuePropertyPathLevelOne<Value extends {}> = {
   [K in keyof PickStoreValueProperties<Value>]: [K];
 }[keyof PickStoreValueProperties<Value>];
 
+/**
+ * @ignore
+ */
 // ["a", "b"] | ["z", "y"]
-// This follows the same pattern as `ComponentValueLevelTwo`.
-type StoreValuePropertyPathLevelTwo<Value extends {}> = {
+export type StoreValuePropertyPathLevelTwo<Value extends {}> = {
   [K in keyof PickStoreValueProperties<Value>]: keyof PickStoreValueProperties<
     NonNullable<PickStoreValueProperties<Value>[K]>
   > extends never // If `Value[K]` is a primitive...

--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -91,7 +91,8 @@ export class Orchestrator<
   never
 > {
   static propTypes: PropTypes.ValidationMap<
-    OrchestratorProps<NamedSchema<string, number, Schema>, StoreNames<Schema>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    OrchestratorProps<NamedSchema<string, number, any>, string>
   > = {
     context: PropTypes.instanceOf(DatabaseContext),
     steps: PropTypes.arrayOf(stepPropType.isRequired).isRequired,
@@ -101,7 +102,8 @@ export class Orchestrator<
   };
 
   static defaultProps: Partial<
-    OrchestratorProps<NamedSchema<string, number, Schema>, StoreNames<Schema>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    OrchestratorProps<NamedSchema<string, number, any>, string>
   > = {
     manageStepTransitions: true,
     provideDatabase: true

--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -98,6 +98,7 @@ export class Orchestrator<
     steps: PropTypes.arrayOf(stepPropType.isRequired).isRequired,
     initialSlug: PropTypes.string,
     manageStepTransitions: PropTypes.bool,
+    provideDatabase: PropTypes.bool,
     onNextStep: PropTypes.func
   };
 

--- a/src/step/StepDefinition.ts
+++ b/src/step/StepDefinition.ts
@@ -30,7 +30,11 @@ export interface StepDefinition<
    * {@link ComponentWrapper.wrapStatic} and
    * {@link ComponentWrapper.wrapDynamic}.
    */
-  componentWrappers: ComponentWrapper<DBSchema, StoreName>[];
+  componentWrappers: ComponentWrapper<
+    DBSchema,
+    StoreName,
+    ComponentValue<DBSchema, StoreName>
+  >[];
 
   /**
    * An optional function that returns a submit button or a similar component.

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -58,7 +58,8 @@ export class Step<
   never
 > {
   static propTypes: PropTypes.ValidationMap<
-    StepProps<NamedSchema<string, number, Schema>, StoreNames<Schema>>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    StepProps<NamedSchema<string, number, any>, string>
   > = {
     context: PropTypes.instanceOf(DatabaseContext),
     componentWrappers: PropTypes.arrayOf(ComponentWrapper.propType.isRequired)

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -26,7 +26,11 @@ export interface StepProps<
   StoreName extends StoreNames<DBSchema["schema"]>
 > {
   context?: DatabaseContext<DBSchema> | null;
-  componentWrappers: ComponentWrapper<DBSchema, StoreName>[];
+  componentWrappers: ComponentWrapper<
+    DBSchema,
+    StoreName,
+    ComponentValue<DBSchema, StoreName>
+  >[];
   submit?: ((nextSlug?: string) => SubmitType) | null;
   afterSubmit?: (() => void) | null;
   nextSlug?:
@@ -142,7 +146,11 @@ export class Step<
   }
 
   private renderComponent(
-    component: ComponentWrapper<DBSchema, StoreName>,
+    component: ComponentWrapper<
+      DBSchema,
+      StoreName,
+      ComponentValue<DBSchema, StoreName>
+    >,
     database?: Database<DBSchema>
   ): void | JSX.Element {
     const { componentValues } = this.state;


### PR DESCRIPTION
With this change, a `DynamicComponentDatabaseMap` now accepts an object for `key`, which specifies how to determine the relevant key. It's passes in a `StoreMap` if needed.