### PR TITLE
MT3-513 #done Add support for specifying certain components as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Support for steps to navigate to different slugs depending on the state of the
   step
 - Support for specifying dynamic keys for `ComponentDatabaseMap`s
+- Support for marking `DynamicComponent`s as required
 
 ### Changed
 

--- a/src/__fixtures__/components/TestDynamicComponent.tsx
+++ b/src/__fixtures__/components/TestDynamicComponent.tsx
@@ -15,7 +15,7 @@ export type TestDynamicComponentProps = DynamicComponentControlledProps<
 export const TestDynamicComponent: React.FunctionComponent<TestDynamicComponentProps> = (
   props: TestDynamicComponentProps
 ): JSX.Element => {
-  const { content, value, onValueChange, disabled } = props;
+  const { content, value, onValueChange, required, disabled } = props;
 
   return (
     <div>
@@ -26,6 +26,7 @@ export const TestDynamicComponent: React.FunctionComponent<TestDynamicComponentP
         onChange={(event: React.ChangeEvent<HTMLInputElement>): void => {
           onValueChange(event.target.value);
         }}
+        required={required}
         disabled={disabled}
       />
     </div>

--- a/src/__fixtures__/forms/dynamicForm.ts
+++ b/src/__fixtures__/forms/dynamicForm.ts
@@ -82,6 +82,7 @@ export const dynamicForm = {
             },
             defaultValue: "test default",
             emptyValue: "",
+            required: true,
             databaseMap: new ComponentDatabaseMap<
               DynamicFormSchema,
               "testStore"

--- a/src/component-wrapper/ComponentWrapper.test.ts
+++ b/src/component-wrapper/ComponentWrapper.test.ts
@@ -167,7 +167,7 @@ describe("#defaultValue", () => {
     expect(componentWrapper.defaultValue).toBeUndefined();
   });
 
-  it("matches the database map provided when wrapping a `DynamicComponent`", () => {
+  it("matches the default value provided when wrapping a `DynamicComponent`", () => {
     const defaultValue = "test default";
 
     const componentWrapper = ComponentWrapper.wrapDynamic(
@@ -205,7 +205,7 @@ describe("#emptyValue", () => {
     expect(componentWrapper.emptyValue).toBeUndefined();
   });
 
-  it("matches the database map provided when wrapping a `DynamicComponent`", () => {
+  it("matches the empty value provided when wrapping a `DynamicComponent`", () => {
     const emptyValue = "test empty";
 
     const componentWrapper = ComponentWrapper.wrapDynamic(
@@ -225,6 +225,45 @@ describe("#emptyValue", () => {
     );
 
     expect(componentWrapper.emptyValue).toEqual(emptyValue);
+  });
+});
+
+describe("#required", () => {
+  it("is false when wrapping a `StaticComponent`", () => {
+    const componentWrapper = ComponentWrapper.wrapStatic(
+      new StaticComponent({
+        key: "test-key",
+        Component: TestClassComponent,
+        props: {
+          content: "test class content"
+        }
+      })
+    );
+
+    expect(componentWrapper.required).toEqual(false);
+  });
+
+  it("matches the required callback provided when wrapping a `DynamicComponent`", () => {
+    const required = jest.fn();
+
+    const componentWrapper = ComponentWrapper.wrapDynamic(
+      new DynamicComponent({
+        key: "test-key",
+        Component: TestDynamicComponent,
+        props: {
+          content: "test content"
+        },
+        defaultValue: "test default",
+        emptyValue: "test empty",
+        required,
+        databaseMap: new ComponentDatabaseMap<TestSchema, typeof storeName>({
+          storeName,
+          key: 0
+        })
+      })
+    );
+
+    expect(componentWrapper.required).toEqual(required);
   });
 });
 
@@ -317,6 +356,7 @@ describe("#render()", () => {
           data-testid="input"
           disabled={true}
           onChange={[Function]}
+          required={false}
           value="test empty"
         />
       </div>
@@ -363,6 +403,7 @@ describe("#render()", () => {
           data-testid="input"
           disabled={false}
           onChange={[Function]}
+          required={false}
           value="testStore/0"
         />
       </div>

--- a/src/component-wrapper/DynamicComponent.test.ts
+++ b/src/component-wrapper/DynamicComponent.test.ts
@@ -172,3 +172,40 @@ describe("#emptyValue", () => {
     expect(component.emptyValue).toEqual(emptyValue);
   });
 });
+
+describe("#required", () => {
+  it("matches the `required` provided to the constructor", () => {
+    const required = jest.fn();
+
+    const component = new DynamicComponent({
+      key: "test-key",
+      Component: TestDynamicComponent,
+      props: { content: "test content" },
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
+      required,
+      databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
+        storeName: "testStore",
+        key: 0
+      })
+    });
+
+    expect(component.required).toEqual(required);
+  });
+
+  it("defaults to false when no `required` is provided to the constructor", () => {
+    const component = new DynamicComponent({
+      key: "test-key",
+      Component: TestDynamicComponent,
+      props: { content: "test content" },
+      defaultValue: "test default value",
+      emptyValue: "test empty value",
+      databaseMap: new ComponentDatabaseMap<TestSchema, "testStore">({
+        storeName: "testStore",
+        key: 0
+      })
+    });
+
+    expect(component.required).toEqual(false);
+  });
+});

--- a/src/component-wrapper/DynamicComponent.ts
+++ b/src/component-wrapper/DynamicComponent.ts
@@ -40,6 +40,11 @@ export interface DynamicComponentControlledProps<Value> {
   onValueChange(value: Value): void;
 
   /**
+   * A flag for whether or not the component is required.
+   */
+  required: boolean;
+
+  /**
    * A flag for whether or not the component is disabled for input.
    *
    * This is set to `true` when waiting for {@link Database} operations to
@@ -138,6 +143,17 @@ export interface DynamicComponentOptions<
    * must always be defined.
    */
   emptyValue: Value;
+
+  /**
+   * Whether or not to require an answer to this component if it is visible.
+   */
+  required?:
+    | ((stepValues: {
+        [key: string]:
+          | ComponentValue<DBSchema, StoreNames<DBSchema["schema"]>>
+          | undefined;
+      }) => boolean)
+    | boolean;
 }
 
 /**
@@ -200,7 +216,8 @@ export class DynamicComponent<
     renderWhen: PropTypes.func.isRequired,
     databaseMap: ComponentDatabaseMap.propType.isRequired,
     defaultValue: PropTypes.any,
-    emptyValue: PropTypes.any.isRequired
+    emptyValue: PropTypes.any.isRequired,
+    required: PropTypes.bool.isRequired
   });
 
   /**
@@ -219,6 +236,7 @@ export class DynamicComponent<
     return {
       value: valuePropType,
       onValueChange: PropTypes.func.isRequired,
+      required: PropTypes.bool.isRequired,
       disabled: PropTypes.bool.isRequired
     };
   }
@@ -234,6 +252,13 @@ export class DynamicComponent<
   readonly databaseMap: ComponentDatabaseMap<DBSchema, StoreName>;
   readonly defaultValue: Value | null | undefined;
   readonly emptyValue: Value;
+  readonly required:
+    | ((stepValues: {
+        [key: string]:
+          | ComponentValue<DBSchema, StoreNames<DBSchema["schema"]>>
+          | undefined;
+      }) => boolean)
+    | boolean;
 
   constructor(
     options: DynamicComponentOptions<Props, DBSchema, StoreName, Value>
@@ -245,7 +270,8 @@ export class DynamicComponent<
       renderWhen,
       databaseMap,
       defaultValue,
-      emptyValue
+      emptyValue,
+      required
     } = options;
 
     this.key = key;
@@ -257,5 +283,6 @@ export class DynamicComponent<
 
     this.renderWhen =
       renderWhen === undefined ? (): boolean => true : renderWhen;
+    this.required = required === undefined ? false : required;
   }
 }

--- a/src/component-wrapper/internal/WrappedComponent.test.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.test.tsx
@@ -56,7 +56,9 @@ const testComponent = new DynamicComponent({
 });
 
 it("renders correctly with all non-context props", () => {
-  const component = create(<WrappedComponent component={testComponent} />);
+  const component = create(
+    <WrappedComponent component={testComponent} required />
+  );
 
   expect(component).toMatchInlineSnapshot(`
     <div>
@@ -67,6 +69,7 @@ it("renders correctly with all non-context props", () => {
         data-testid="input"
         disabled={true}
         onChange={[Function]}
+        required={true}
         value="test empty"
       />
     </div>
@@ -85,7 +88,9 @@ it("renders correctly with an undefined default value for the component", () => 
     databaseMap: testDatabaseMap
   });
 
-  const component = create(<WrappedComponent component={dynamicComponent} />);
+  const component = create(
+    <WrappedComponent component={dynamicComponent} required />
+  );
 
   expect(component).toMatchInlineSnapshot(`
     <div>
@@ -96,6 +101,7 @@ it("renders correctly with an undefined default value for the component", () => 
         data-testid="input"
         disabled={true}
         onChange={[Function]}
+        required={true}
         value="test empty"
       />
     </div>
@@ -110,7 +116,11 @@ it("renders correctly with a database context", async () => {
     <DatabaseProvider context={DBContext}>
       <DBContext.Consumer>
         {(database): JSX.Element => (
-          <WrappedComponent database={database} component={testComponent} />
+          <WrappedComponent
+            database={database}
+            component={testComponent}
+            required
+          />
         )}
       </DBContext.Consumer>
     </DatabaseProvider>
@@ -125,6 +135,7 @@ it("renders correctly with a database context", async () => {
         data-testid="input"
         disabled={true}
         onChange={[Function]}
+        required={true}
         value="test empty"
       />
     </div>
@@ -150,6 +161,7 @@ it("fetches the stored value specified by the `databaseMap` when a database prov
             <WrappedComponent
               database={database}
               component={testComponent}
+              required
               onChange={onChange}
             />
           )}
@@ -177,6 +189,7 @@ it("fetches the stored value specified by the `databaseMap` when a database prov
         data-testid="input"
         disabled={false}
         onChange={[Function]}
+        required={true}
         value="testStore/0"
       />
     </div>
@@ -234,6 +247,7 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
             <WrappedComponent
               database={database}
               component={dynamicComponent}
+              required
             />
           )}
         </DBContext.Consumer>
@@ -288,6 +302,7 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
             <WrappedComponent
               database={database}
               component={dynamicComponent}
+              required
             />
           )}
         </DBContext.Consumer>
@@ -309,6 +324,7 @@ it("fetches the stored value specified by the `databaseMap` and uses the specifi
         data-testid="input"
         disabled={false}
         onChange={[Function]}
+        required={true}
         value="new value"
       />
     </div>
@@ -328,7 +344,11 @@ it("uses the empty value before it fetches from the database", async () => {
       <DatabaseProvider context={DBContext}>
         <DBContext.Consumer>
           {(database): JSX.Element => (
-            <WrappedComponent database={database} component={testComponent} />
+            <WrappedComponent
+              database={database}
+              component={testComponent}
+              required
+            />
           )}
         </DBContext.Consumer>
       </DatabaseProvider>
@@ -346,6 +366,7 @@ it("uses the empty value before it fetches from the database", async () => {
         data-testid="input"
         disabled={true}
         onChange={[Function]}
+        required={true}
         value="test empty"
       />
     </div>
@@ -367,7 +388,11 @@ it("uses the default value when fetching the stored value returns `undefined`", 
       <DatabaseProvider context={DBContext}>
         <DBContext.Consumer>
           {(database): JSX.Element => (
-            <WrappedComponent database={database} component={testComponent} />
+            <WrappedComponent
+              database={database}
+              component={testComponent}
+              required
+            />
           )}
         </DBContext.Consumer>
       </DatabaseProvider>
@@ -386,6 +411,7 @@ it("uses the default value when fetching the stored value returns `undefined`", 
         data-testid="input"
         disabled={false}
         onChange={[Function]}
+        required={true}
         value="test default"
       />
     </div>
@@ -419,6 +445,7 @@ it("uses the empty value when fetching the stored value returns `undefined` and 
             <WrappedComponent
               database={database}
               component={dynamicComponent}
+              required
             />
           )}
         </DBContext.Consumer>
@@ -438,6 +465,7 @@ it("uses the empty value when fetching the stored value returns `undefined` and 
         data-testid="input"
         disabled={false}
         onChange={[Function]}
+        required={true}
         value="test empty"
       />
     </div>
@@ -467,7 +495,11 @@ it("is disabled while the database is opening", async () => {
     <DatabaseProvider context={DBContext}>
       <DBContext.Consumer>
         {(database): JSX.Element => (
-          <WrappedComponent database={database} component={dynamicComponent} />
+          <WrappedComponent
+            database={database}
+            component={dynamicComponent}
+            required
+          />
         )}
       </DBContext.Consumer>
     </DatabaseProvider>
@@ -506,7 +538,11 @@ it("is disabled while fetching the stored value from the database", async () => 
     <DatabaseProvider context={DBContext}>
       <DBContext.Consumer>
         {(database): JSX.Element => (
-          <WrappedComponent database={database} component={dynamicComponent} />
+          <WrappedComponent
+            database={database}
+            component={dynamicComponent}
+            required
+          />
         )}
       </DBContext.Consumer>
     </DatabaseProvider>

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -24,6 +24,7 @@ export interface WrappedComponentProps<
   Value extends ComponentValue<DBSchema, StoreName>
 > {
   component: DynamicComponent<Props, DBSchema, StoreName, Value>;
+  required: boolean;
   onChange?: ((value: Value) => void) | null;
   database?: Database<DBSchema> | null;
 }
@@ -73,6 +74,7 @@ export class WrappedComponent<
     >
   > = {
     component: DynamicComponent.propType.isRequired,
+    required: PropTypes.bool.isRequired,
     onChange: PropTypes.func,
     database: PropTypes.instanceOf(Database)
   };
@@ -132,13 +134,14 @@ export class WrappedComponent<
       return <div>Something went wrong!</div>;
     }
 
-    const { database } = this.props;
+    const { database, required } = this.props;
     const { value, isFetching } = this.state;
     const { key, Component, props } = component;
 
     const controlledProps: DynamicComponentControlledProps<Value> = {
       value,
       onValueChange: this.onValueChange.bind(this),
+      required,
       disabled: !database || isFetching
     };
 

--- a/src/component-wrapper/makeDynamic.test.tsx
+++ b/src/component-wrapper/makeDynamic.test.tsx
@@ -16,6 +16,7 @@ it("renders correctly for function components", () => {
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -27,6 +28,7 @@ it("renders correctly for function components", () => {
       type,
       inputValue,
       onInputValueChange,
+      inputRequired,
       inputDisabled
     } = nullValuesAsUndefined(props);
 
@@ -36,6 +38,7 @@ it("renders correctly for function components", () => {
         type={type}
         value={inputValue}
         onChange={onInputValueChange}
+        required={inputRequired}
         disabled={inputDisabled}
       />
     );
@@ -43,13 +46,14 @@ it("renders correctly for function components", () => {
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestFunctionComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -61,6 +65,7 @@ it("renders correctly for function components", () => {
       type="text"
       value="test value"
       onValueChange={jest.fn()}
+      required={true}
       disabled={true}
     />
   );
@@ -70,6 +75,7 @@ it("renders correctly for function components", () => {
       className="test-class"
       disabled={true}
       onChange={[Function]}
+      required={true}
       type="text"
       value="test value"
     />
@@ -83,6 +89,7 @@ it("renders correctly for class components", () => {
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -93,6 +100,7 @@ it("renders correctly for class components", () => {
         type,
         inputValue,
         onInputValueChange,
+        inputRequired,
         inputDisabled
       } = nullValuesAsUndefined(this.props);
 
@@ -102,6 +110,7 @@ it("renders correctly for class components", () => {
           type={type}
           value={inputValue}
           onChange={onInputValueChange}
+          required={inputRequired}
           disabled={inputDisabled}
         />
       );
@@ -110,13 +119,14 @@ it("renders correctly for class components", () => {
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestClassComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -128,6 +138,7 @@ it("renders correctly for class components", () => {
       type="text"
       value="test value"
       onValueChange={jest.fn()}
+      required={true}
       disabled={true}
     />
   );
@@ -137,6 +148,7 @@ it("renders correctly for class components", () => {
       className="test-class"
       disabled={true}
       onChange={[Function]}
+      required={true}
       type="text"
       value="test value"
     />
@@ -146,13 +158,14 @@ it("renders correctly for class components", () => {
 it("creates a component with a sensible display name when the original component is an intrinsic element", () => {
   const Component = makeDynamic<
     React.InputHTMLAttributes<HTMLInputElement>,
-    "value" | "onChange" | "disabled",
+    "value" | "onChange" | "required" | "disabled",
     string
   >(
     "input",
     {
       value: "value",
       onValueChange: "onChange",
+      required: "required",
       disabled: "disabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -168,6 +181,7 @@ it("creates a component with a sensible display name when the original component
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -179,6 +193,7 @@ it("creates a component with a sensible display name when the original component
       type,
       inputValue,
       onInputValueChange,
+      inputRequired,
       inputDisabled
     } = nullValuesAsUndefined(props);
 
@@ -188,6 +203,7 @@ it("creates a component with a sensible display name when the original component
         type={type}
         value={inputValue}
         onChange={onInputValueChange}
+        required={inputRequired}
         disabled={inputDisabled}
       />
     );
@@ -195,13 +211,14 @@ it("creates a component with a sensible display name when the original component
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestFunctionComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -217,6 +234,7 @@ it("creates a component with a sensible display name when the original component
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -227,6 +245,7 @@ it("creates a component with a sensible display name when the original component
         type,
         inputValue,
         onInputValueChange,
+        inputRequired,
         inputDisabled
       } = nullValuesAsUndefined(this.props);
 
@@ -236,6 +255,7 @@ it("creates a component with a sensible display name when the original component
           type={type}
           value={inputValue}
           onChange={onInputValueChange}
+          required={inputRequired}
           disabled={inputDisabled}
         />
       );
@@ -244,13 +264,14 @@ it("creates a component with a sensible display name when the original component
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestClassComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -262,13 +283,14 @@ it("creates a component with a sensible display name when the original component
 it("creates a component with the correct proptypes when the original component is an intrinsic element", () => {
   const Component = makeDynamic<
     React.InputHTMLAttributes<HTMLInputElement>,
-    "value" | "onChange" | "disabled",
+    "value" | "onChange" | "required" | "disabled",
     string
   >(
     "input",
     {
       value: "value",
       onValueChange: "onChange",
+      required: "required",
       disabled: "disabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -286,6 +308,7 @@ it("creates a component with the correct proptypes when the original component h
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -297,6 +320,7 @@ it("creates a component with the correct proptypes when the original component h
       type,
       inputValue,
       onInputValueChange,
+      inputRequired,
       inputDisabled
     } = nullValuesAsUndefined(props);
 
@@ -306,6 +330,7 @@ it("creates a component with the correct proptypes when the original component h
         type={type}
         value={inputValue}
         onChange={onInputValueChange}
+        required={inputRequired}
         disabled={inputDisabled}
       />
     );
@@ -313,13 +338,14 @@ it("creates a component with the correct proptypes when the original component h
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestFunctionComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -337,6 +363,7 @@ it("creates a component with the correct proptypes when the original component h
 
     inputValue?: string | null;
     onInputValueChange(value: React.ChangeEvent<HTMLInputElement>): void;
+    inputRequired: boolean;
     inputDisabled: boolean;
   }
 
@@ -348,6 +375,7 @@ it("creates a component with the correct proptypes when the original component h
       type,
       inputValue,
       onInputValueChange,
+      inputRequired,
       inputDisabled
     } = nullValuesAsUndefined(props);
 
@@ -357,6 +385,7 @@ it("creates a component with the correct proptypes when the original component h
         type={type}
         value={inputValue}
         onChange={onInputValueChange}
+        required={inputRequired}
         disabled={inputDisabled}
       />
     );
@@ -367,18 +396,20 @@ it("creates a component with the correct proptypes when the original component h
     type: PropTypes.oneOf<"text">(["text"]).isRequired,
     inputValue: PropTypes.string,
     onInputValueChange: PropTypes.func.isRequired,
+    inputRequired: PropTypes.bool.isRequired,
     inputDisabled: PropTypes.bool.isRequired
   };
 
   const Component = makeDynamic<
     TestProps,
-    "inputValue" | "onInputValueChange" | "inputDisabled",
+    "inputValue" | "onInputValueChange" | "inputRequired" | "inputDisabled",
     string
   >(
     TestFunctionComponent,
     {
       value: "inputValue",
       onValueChange: "onInputValueChange",
+      required: "inputRequired",
       disabled: "inputDisabled"
     },
     (event: React.ChangeEvent<HTMLInputElement>) => event.target.value
@@ -393,6 +424,7 @@ it("creates a component with the correct proptypes when the original component h
       type: "text",
       value: "value",
       onValueChange: () => {},
+      required: true,
       disabled: true
     },
     "prop",
@@ -408,6 +440,7 @@ it("creates a component with the correct proptypes when the original component h
       type: "not-text",
       value: 1,
       onValueChange: "on-change",
+      required: "required",
       disabled: "disabled"
     },
     "prop",
@@ -427,6 +460,9 @@ it("creates a component with the correct proptypes when the original component h
       ],
       Array [
         "Warning: Failed prop type: Invalid prop \`onValueChange\` of type \`string\` supplied to \`makeDynamic(TestFunctionComponent)\`, expected \`function\`.",
+      ],
+      Array [
+        "Warning: Failed prop type: Invalid prop \`required\` of type \`string\` supplied to \`makeDynamic(TestFunctionComponent)\`, expected \`boolean\`.",
       ],
       Array [
         "Warning: Failed prop type: Invalid prop \`disabled\` of type \`string\` supplied to \`makeDynamic(TestFunctionComponent)\`, expected \`boolean\`.",

--- a/src/component-wrapper/makeDynamic.tsx
+++ b/src/component-wrapper/makeDynamic.tsx
@@ -35,6 +35,11 @@ export interface MakeDynamicPropMap<PropsToMap> {
   onValueChange: keyof PropsToMap & string;
 
   /**
+   * The name of the prop on the wrapped component to map `required` to.
+   */
+  required: keyof PropsToMap & string;
+
+  /**
    * The name of the prop on the wrapped component to map `disabled` to.
    */
   disabled: keyof PropsToMap & string;
@@ -63,7 +68,7 @@ const mapDynamicPropsToComponentProps = <
   dynamicProps: Readonly<
     Subtract<Props, PropsToMap> & DynamicComponentControlledProps<Value>
   >,
-  { value, onValueChange, disabled }: MakeDynamicPropMap<PropsToMap>,
+  { value, onValueChange, required, disabled }: MakeDynamicPropMap<PropsToMap>,
   valueChangeAdapter: MakeDynamicValueChangeAdapter<Value>
 ): Props => {
   const copyOfDynamicProps = {
@@ -73,6 +78,7 @@ const mapDynamicPropsToComponentProps = <
 
   delete copyOfDynamicProps.value;
   delete copyOfDynamicProps.onValueChange;
+  delete copyOfDynamicProps.required;
   delete copyOfDynamicProps.disabled;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,6 +92,7 @@ const mapDynamicPropsToComponentProps = <
     ...copyOfDynamicProps,
     [value]: dynamicProps.value,
     [onValueChange]: handleValueChange,
+    [required]: dynamicProps.required,
     [disabled]: dynamicProps.disabled
   } as Props;
 };
@@ -96,7 +103,7 @@ const mapComponentPropTypesToDynamicPropTypes = <
   Value
 >(
   componentPropTypes: Readonly<React.WeakValidationMap<Props>> | undefined,
-  { value, onValueChange, disabled }: MakeDynamicPropMap<PropsToMap>
+  { value, onValueChange, required, disabled }: MakeDynamicPropMap<PropsToMap>
 ): React.WeakValidationMap<Subtract<Props, PropsToMap> &
   DynamicComponentControlledProps<Value>> => {
   const copyOfComponentPropTypes = {
@@ -107,6 +114,7 @@ const mapComponentPropTypesToDynamicPropTypes = <
 
   delete copyOfComponentPropTypes[value];
   delete copyOfComponentPropTypes[onValueChange];
+  delete copyOfComponentPropTypes[required];
   delete copyOfComponentPropTypes[disabled];
 
   const valuePropType = componentPropTypes

--- a/src/orchestrator/Orchestrator.test.tsx
+++ b/src/orchestrator/Orchestrator.test.tsx
@@ -32,6 +32,7 @@ it("renders correctly with all props", async () => {
       manageStepTransitions={false}
       provideDatabase={false}
       onNextStep={(): void => {}}
+      onIncompleteStep={(): void => {}}
     />
   );
 

--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -71,6 +71,12 @@ export interface OrchestratorProps<
    * @param slug - The next {@link StepDefinition.slug}.
    */
   onNextStep?: ((slug?: string) => void) | null;
+
+  /**
+   * The callback to call when the {@link Orchestrator} has failed to
+   * transition to the next {@link StepDefinition} due to missing values.
+   */
+  onIncompleteStep?: ((keysMissingValues?: string[]) => void) | null;
 }
 
 interface OrchestratorState {
@@ -116,7 +122,7 @@ export class Orchestrator<
    * @ignore
    */
   render(): JSX.Element {
-    const { context, provideDatabase } = this.props;
+    const { context, provideDatabase, onIncompleteStep } = this.props;
 
     const { slug, nextSlug, componentWrappers, submit } = this.currentStep();
 
@@ -129,6 +135,7 @@ export class Orchestrator<
         afterSubmit={(): void => {
           this.handleSubmit();
         }}
+        onIncompleteSubmit={onIncompleteStep}
         nextSlug={nextSlug}
         onNextSlugChange={(slug?: string): void => {
           this.handleNextSlugChange(slug);


### PR DESCRIPTION
If a required component doesn't have a corresponding value set, we call a new `onIncompleteStep` callback instead of processing the submission.