### PR TITLE
Release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.0.5] - 06-02-2020
+
 ### Added
 
 - Support for steps to navigate to different slugs depending on the state of the
@@ -81,7 +83,8 @@ and this project adheres to
 - `makeDatabase`, a Higher Order Component to make wrapping dynamic components
   more straightforward
 
-[unreleased]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.4...HEAD
+[unreleased]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/LBHackney-IT/remultiform/compare/v0.0.1...v0.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remultiform",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remultiform",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The React multipage form builder",
   "license": "MIT",
   "main": "dist/cjs/index.js",


### PR DESCRIPTION
### Added

- Support for steps to navigate to different slugs depending on the state of the
  step
- Support for specifying dynamic keys for `ComponentDatabaseMap`s
- Support for marking `DynamicComponent`s as required

### Changed

- Simplifed some generic types

### Fixed

- Stopped trying to persist data in `Step`, when the step has no
  `DynamicComponent`s