### PR TITLE
Fix errors fetching missing structured data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed errors accessing structured data that is missing from a `Store`
+
 ## [0.0.5] - 06-02-2020
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8954,6 +8954,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
       "integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -241,27 +241,33 @@ export class WrappedComponent<
       return undefined;
     }
 
-    let value = storedValue as ComponentValue<DBSchema, StoreName>;
+    let value = storedValue as ComponentValue<DBSchema, StoreName> | undefined;
 
     if (property) {
-      if (property.length > 0) {
-        const k = property[0] as StoreValuePropertyPathLevelOne<
-          ComponentValue<DBSchema, StoreName>
-        >[0];
-
-        value = value[k] as ComponentValue<DBSchema, StoreName>;
+      if (value === undefined) {
+        value = {};
       }
 
+      const k = property[0] as StoreValuePropertyPathLevelOne<
+        ComponentValue<DBSchema, StoreName>
+      >[0];
+
+      value = value[k] as ComponentValue<DBSchema, StoreName>;
+
       if (property.length > 1) {
-        const k = property[1] as StoreValuePropertyPathLevelTwo<
+        if (value === undefined) {
+          value = {};
+        }
+
+        const j = property[1] as StoreValuePropertyPathLevelTwo<
           ComponentValue<DBSchema, StoreName>
         >[1];
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value = (value as any)[k] as ComponentValue<DBSchema, StoreName>;
+        value = (value as any)[j] as ComponentValue<DBSchema, StoreName>;
       }
     }
 
-    return value as Value;
+    return value as Value | undefined;
   }
 }


### PR DESCRIPTION
When a `property` is passed in a database map, we dig into the stored data. But if the data is missing, we need to avoid attempting to access data that doesn't exist.