### PR TITLE
Simplify StepDefinition.key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified `StepDefinition.key`
+
 ## [0.0.6] - 06-02-2020
 
 ### Fixed
@@ -25,7 +29,7 @@ and this project adheres to
 
 ### Changed
 
-- Simplifed some generic types
+- Simplified some generic types
 
 ### Fixed
 

--- a/src/component-wrapper/internal/WrappedComponent.test.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.test.tsx
@@ -339,7 +339,7 @@ it("uses the empty value before it fetches from the database", async () => {
 
   let component: ReactTestRenderer | undefined = undefined;
 
-  await act(async () => {
+  act(() => {
     component = create(
       <DatabaseProvider context={DBContext}>
         <DBContext.Consumer>
@@ -353,8 +353,6 @@ it("uses the empty value before it fetches from the database", async () => {
         </DBContext.Consumer>
       </DatabaseProvider>
     );
-
-    await openPromise;
   });
 
   expect(component).toMatchInlineSnapshot(`
@@ -372,6 +370,7 @@ it("uses the empty value before it fetches from the database", async () => {
     </div>
   `);
 
+  await openPromise;
   await get.settle;
 });
 

--- a/src/component-wrapper/internal/WrappedComponent.tsx
+++ b/src/component-wrapper/internal/WrappedComponent.tsx
@@ -227,14 +227,9 @@ export class WrappedComponent<
     database: Database<DBSchema>,
     databaseMap: ComponentDatabaseMap<DBSchema, StoreName>
   ): Promise<Value | undefined> {
-    const { storeName, property } = databaseMap;
+    const { storeName, key, property } = databaseMap;
 
-    const storeKey = await databaseMap.getKey(database);
-
-    if (storeKey === undefined) {
-      return undefined;
-    }
-
+    const storeKey = typeof key === "function" ? key() : key;
     const storedValue = await database.get(storeName, storeKey);
 
     if (storedValue === undefined) {


### PR DESCRIPTION
In practice we would need the key to derive the key from the database, so there's no value in the added complexity.