### PR TITLE
MT3-593 Fix deletion of hidden component values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Stopped saving hidden answers immediately after deleting them
+
 ## [0.1.0] - 12-03-2020
 
 ### Changed


### PR DESCRIPTION
Prior to this change, we were deleting the value from the store, then immediately saving the cached version again.

We need to handle properties differently from store value. We only want to remove the value of the child property, not the entire value in the former case.

This should probably have some test coverage, but we don't really have time to do that.