### PR TITLE
Return a boolean when submitting to indicate status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ## Changed
 
-- Bump `idb` from `4.0.5` to `5.0.1`
+- Bumped `idb` from `4.0.5` to `5.0.1`
+- Changes the `onSubmit` prop for `SubmitType` to return a boolean status
 
 ### Fixed
 

--- a/src/step/Submit.ts
+++ b/src/step/Submit.ts
@@ -12,8 +12,10 @@ export interface SubmitProps {
    * implementation of {@link StepDefinition.Submit} must catch any exceptions
    * thrown by the promise returned by this callback, and handle them
    * appropriately, so they aren't lost to the ether.
+   *
+   * Returns `true` if the submission succeeded. Otherwise returns `false.
    */
-  onSubmit(): Promise<void>;
+  onSubmit(): Promise<boolean>;
 }
 
 /**

--- a/src/step/internal/Step.tsx
+++ b/src/step/internal/Step.tsx
@@ -139,7 +139,7 @@ export class Step<
         {Submit && (
           <Submit
             key="submit"
-            onSubmit={(): Promise<void> => this.handleSubmit(database)}
+            onSubmit={(): Promise<boolean> => this.handleSubmit(database)}
           />
         )}
       </>
@@ -200,7 +200,7 @@ export class Step<
     }
   }
 
-  private async handleSubmit(database?: Database<DBSchema>): Promise<void> {
+  private async handleSubmit(database?: Database<DBSchema>): Promise<boolean> {
     const { componentWrappers, afterSubmit, onIncompleteSubmit } = this.props;
     const { componentValues } = this.state;
 
@@ -224,7 +224,7 @@ export class Step<
         onIncompleteSubmit(keysMissingValues);
       }
 
-      return;
+      return false;
     }
 
     if (database) {
@@ -269,6 +269,8 @@ export class Step<
     if (afterSubmit) {
       afterSubmit();
     }
+
+    return true;
   }
 
   private async persistValuesToDatabase(


### PR DESCRIPTION
A return value of `true` indicates that it submitted, while `false` means it was missing some values.
